### PR TITLE
Anvil based chunk loading (instead of draw.rs)

### DIFF
--- a/fastnbt/src/anvil/mod.rs
+++ b/fastnbt/src/anvil/mod.rs
@@ -33,6 +33,7 @@ pub struct ChunkLocation {
 // Encodes how the NBT-Data is compressed
 #[derive(Debug)]
 pub struct ChunkMeta {
+    //  the compressed data is len-1 bytes
     pub len: u32,
     pub compression_scheme: CompressionScheme,
 }
@@ -118,6 +119,7 @@ impl<S: Seek + Read> Region<S> {
         Ok(decompress_chunk(&data))
     }
 }
+
 // Read Information Bytes of Minecraft Chunk and decompress it
 fn decompress_chunk(data: &Vec<u8>) -> Vec<u8> {
     // Metadata encodes the length in bytes and the compression type
@@ -133,6 +135,37 @@ fn decompress_chunk(data: &Vec<u8>) -> Vec<u8> {
     // read the whole Chunk
     decoder.read_to_end(&mut outbuf).unwrap();
     outbuf
+}
+
+/// Call f function with earch uncompressed, non-empty chunk
+pub fn for_each_chunk(mut r: Region<std::fs::File>, mut f: impl FnMut(usize, usize, &Vec<u8> )) -> Result<()>{
+    let mut offsets = Vec::<ChunkLocation>::new();
+
+    // Build list of existing chunks
+    for x in 0..32 {
+        for z in 0..32 {
+            let loc = r.chunk_location(x, z)?;
+            // 0,0 chunk location means the chunk isn't present.
+            // cannot decide if this means we should return an error from chunk_location() or not.
+            if loc.begin_sector != 0 && loc.sector_count != 0 {
+                offsets.push(loc);
+            }
+        }
+    }
+    // sort for efficient file seeks during processing
+    offsets.sort_by(|o1, o2| o2.begin_sector.cmp(&o1.begin_sector));
+    offsets.shrink_to_fit();
+
+    while !offsets.is_empty() {
+        let location: ChunkLocation = offsets.pop().ok_or(0).unwrap();
+        // TODO: move outside the loop
+        let mut buf = vec![0u8; location.sector_count * SECTOR_SIZE];
+        r.load_chunk(&location, &mut buf)?;
+        let raw = decompress_chunk(&buf);
+        f(location.x, location.z, &raw)
+    
+    }
+    Ok(())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This extends `fastnbt::anvil::Region` to do chunk loading and decompression (but not NBT decoding). 

Most usefull probably is `.load_chunk_nbt_at_location(x, z)` which handles location lookup and decompression.

Changing draw.rs to use  `.load_chunk_nbt_at_location(x, z)` for some reason makes `anvil render` run somewhat fasters for reasons I do not have looked into.

Also notable is `.for_each_chunk()` which moves iteration into fastnbt::anvil::Region.