### PR TITLE
Fix: stream parser errors on Minecraft Unicode

### DIFF
--- a/fastnbt/src/stream.rs
+++ b/fastnbt/src/stream.rs
@@ -237,9 +237,9 @@ impl<R: Read> Parser<R> {
         let mut buf = vec![0; name_len];
         self.reader.read_exact(&mut buf[..])?;
 
-        Ok(std::str::from_utf8(&buf[..])
+        Ok(cesu8::from_java_cesu8(&buf[..])
             .map_err(|_| Error::nonunicode(Vec::from(&buf[..])))?
-            .to_owned())
+            .into_owned())
     }
 
     fn read_payload(&mut self, tag: Tag, name: Name) -> Result<Value> {

--- a/fastnbt/src/test/stream.rs
+++ b/fastnbt/src/test/stream.rs
@@ -120,6 +120,30 @@ fn simple_string() -> Result<()> {
 }
 
 #[test]
+fn cesu8_string_in_nbt() -> Result<()> {
+    // In the builder we always convert to java cesu8 form for strings anyway,
+    // but this test is more explicit and includes some unicode that actually
+    // has a different representation in cesu8 and utf-8.
+    let modified_unicode_str = cesu8::to_java_cesu8("😈");
+
+    let payload = Builder::new()
+        .tag(Tag::String)
+        .name("cesu8")
+        .raw_len(modified_unicode_str.len())
+        .raw_bytes(&modified_unicode_str)
+        .build();
+
+    let mut parser = Parser::new(payload.as_slice());
+
+    assert_eq!(
+        parser.next()?,
+        Value::String(name("cesu8"), "😈".to_owned())
+    );
+
+    Ok(())
+}
+
+#[test]
 fn simple_byte_array() -> Result<()> {
     let payload = Builder::new()
         .tag(Tag::ByteArray)


### PR DESCRIPTION
When parsing a size prefixed string, the stream parser attempts to parse the string as UTF-8 via the standard library, which errors on Minecraft's CESU-8 (Java variant) encoded string.  This also causes attempts to skip over a compound containing a string to fail.
0be03dc1877c0e19810f96d9f7e2ac728ad6c64c has fixed this in the Serde parser but not the stream parser.

Unrelated: I think it's a good idea to change the error from a string to a custom error type (by using `thiserror`) so that users can check what error has occurred without relying on the content of the string. What do you think?