### PR TITLE
Fix the `json-pretty` output to be pretty

### DIFF
--- a/tools/src/bin/region-dump.rs
+++ b/tools/src/bin/region-dump.rs
@@ -79,7 +79,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     serde_json::ser::to_writer(out, &chunk).unwrap();
                 }
                 "json-pretty" => {
-                    serde_json::ser::to_writer(out, &chunk).unwrap();
+                    serde_json::ser::to_writer_pretty(out, &chunk).unwrap();
                 }
                 _ => panic!("unknown output format '{}'", output_format),
             }


### PR DESCRIPTION
Currently both `json` and `json-pretty` outputs are the same compact format - probably because they're both using the same [`to_writer`](https://docs.serde.rs/serde_json/fn.to_writer.html) call from `serde_json`.  Changing the `json-pretty` output to use [`to_writer_pretty`](https://docs.serde.rs/serde_json/fn.to_writer_pretty.html) gives the desired effect.