### PR TITLE
Improve multithreading support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
  "flate2",
  "hematite-nbt",
  "image",
- "lazy_static",
  "log",
  "num_enum",
+ "once_cell",
  "serde",
  "serde_json",
 ]
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"

--- a/fastanvil/Cargo.toml
+++ b/fastanvil/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = "1.3"
 bit_field = "0.10"
 serde = { version = "1.0", features= ["derive"] }
 log = "0.4"
-lazy_static = "1.4.0"
+once_cell = "1.9"
 hematite-nbt = "0.5"
 
 [dev-dependencies]

--- a/fastanvil/Cargo.toml
+++ b/fastanvil/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 fastnbt = { path = "../fastnbt", version = "1" }
 flate2 = "1.0"
 num_enum = "0.5"
-image = "0.23"
+image = { version = "0.23", default-features = false }
 byteorder = "1.3"
 bit_field = "0.10"
 serde = { version = "1.0", features= ["derive"] }

--- a/fastanvil/src/java/mod.rs
+++ b/fastanvil/src/java/mod.rs
@@ -1,7 +1,5 @@
 use std::ops::Range;
 
-use lazy_static::lazy_static;
-
 pub mod pre18;
 
 mod block;
@@ -17,24 +15,24 @@ pub use heightmaps::*;
 pub use section::*;
 pub use section_data::*;
 pub use section_tower::*;
+
+use once_cell::sync::Lazy;
 use serde::Deserialize;
 
 use crate::{biome::Biome, Chunk, HeightMode};
 
-lazy_static! {
-    pub static ref AIR: Block = Block {
-        name: "minecraft:air".to_owned(),
-        encoded: "minecraft:air|".to_owned(),
-        snowy: false,
-        properties: Default::default(),
-    };
-    pub static ref SNOW_BLOCK: Block = Block {
-        name: "minecraft:snow_block".to_owned(),
-        encoded: "minecraft:snow_block|".to_owned(),
-        snowy: true,
-        properties: Default::default(),
-    };
-}
+pub static AIR: Lazy<Block> = Lazy::new(|| Block {
+    name: "minecraft:air".to_owned(),
+    encoded: "minecraft:air|".to_owned(),
+    snowy: false,
+    properties: Default::default(),
+});
+pub static SNOW_BLOCK: Lazy<Block> = Lazy::new(|| Block {
+    name: "minecraft:snow_block".to_owned(),
+    encoded: "minecraft:snow_block|".to_owned(),
+    snowy: true,
+    properties: Default::default(),
+});
 
 /// A Minecraft chunk.
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This PR:
- Replaces all uses of `RefCell` with `Mutex`, `RwLock`, or `OnceCell`'s sync variant
- Replaces all uses of `Rc` with `Arc`
- Adds `Send + Sync` bounds to all traits so that their trait objects are thread-safe
- Since this added `once_cell`, I replaced the uses of `lazy_static` with `once_cell`
- Disables unused features in the `image` crate (this change is mostly unrelated to threading and I can remove it if necessary)

Some of these changes likely have some performance overhead; two potential improvements would be reworking heightmap caching so that it only needs to be updated once and can use `once_cell`, and sharing the lock in the `RegionBuffer::for_each_chunk` function rather than unlocking it and relocking it many times (in each `chunk_location` call).

Fixes #46.