### PR TITLE
Add `nbt!` macro

### DIFF
--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -135,6 +135,8 @@ pub mod stream;
 mod arrays;
 mod de_arrays;
 mod value;
+#[macro_use]
+mod macros;
 
 pub use arrays::*;
 pub use value::*;

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -1,0 +1,177 @@
+// Taken from serde_json and modified for NBT
+// https://github.com/serde-rs/json/blob/829175e6069fb16672875f125f6afdd7c6da1dec/src/macros.rs#L60-L303
+#[macro_export]
+macro_rules! nbt {
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        vec![$($elems),*]
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        nbt!(@array [$($elems,)* nbt!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        nbt!(@array [$($elems,)* nbt!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        nbt!(@array [$($elems,)* nbt!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        nbt!(@array [$($elems,)* nbt!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        nbt!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        nbt_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: nbt!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        nbt!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        nbt_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        nbt!(@object $object [$($key)+] (nbt!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        nbt!(@object $object [$($key)+] (nbt!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        nbt!(@object $object [$($key)+] (nbt!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        nbt!(@object $object [$($key)+] (nbt!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        nbt!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        nbt!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        nbt_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        nbt_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        nbt!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        nbt_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        nbt!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: nbt!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    ([]) => {
+        $crate::Value::List(vec![])
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::Value::List(nbt!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::Value::Compound(std::collections::HashMap::new())
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::Value::Compound({
+            let mut object = std::collections::HashMap::new();
+            nbt!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any value of T where fastnbt::Value: From<T>
+    ($other:expr) => {
+        $crate::to_value($other)
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! nbt_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! nbt_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -170,6 +170,18 @@ macro_rules! nbt {
     // Must be invoked as: nbt!($($json)+)
     //////////////////////////////////////////////////////////////////////////
 
+    ([B;]) => {
+        $crate::Value::ByteArray($crate::ByteArray::new(vec![]))
+    };
+
+    ([I;]) => {
+        $crate::Value::IntArray($crate::IntArray::new(vec![]))
+    };
+
+    ([L;]) => {
+        $crate::Value::LongArray($crate::LongArray::new(vec![]))
+    };
+
     ([]) => {
         $crate::Value::List(vec![])
     };

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -42,6 +42,38 @@ macro_rules! nbt {
         nbt_unexpected!($unexpected)
     };
 
+    /* ------------ IntArray types ------------ */
+
+    // Done with trailing comma.
+    (@int_array [$($elems:expr,)*]) => {
+        vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@int_array [$($elems:expr),*]) => {
+        vec![$($elems),*]
+    };
+
+    // Next element is an expression followed by comma.
+    (@int_array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        nbt!(@int_array [$($elems,)* $next,] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@int_array [$($elems:expr,)*] $last:expr) => {
+        nbt!(@int_array [$($elems,)* $last])
+    };
+
+    // Comma after the most recent element.
+    (@int_array [$($elems:expr),*] , $($rest:tt)*) => {
+        nbt!(@int_array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@int_array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        nbt_unexpected!($unexpected)
+    };
+
     //////////////////////////////////////////////////////////////////////////
     // TT muncher for parsing the inside of an object {...}. Each entry is
     // inserted into the given map variable.
@@ -140,6 +172,18 @@ macro_rules! nbt {
 
     ([]) => {
         $crate::Value::List(vec![])
+    };
+
+    ([B; $($tt:tt)+ ]) => {
+        $crate::Value::ByteArray($crate::ByteArray::new(nbt!(@int_array [] $($tt)+)))
+    };
+
+    ([I; $($tt:tt)+ ]) => {
+        $crate::Value::IntArray($crate::IntArray::new(nbt!(@int_array [] $($tt)+)))
+    };
+
+    ([L; $($tt:tt)+ ]) => {
+        $crate::Value::LongArray($crate::LongArray::new(nbt!(@int_array [] $($tt)+)))
     };
 
     ([ $($tt:tt)+ ]) => {

--- a/fastnbt/src/test/macros.rs
+++ b/fastnbt/src/test/macros.rs
@@ -65,15 +65,15 @@ fn nbt() {
     );
 
     assert_eq!(
-        nbt!(ByteArray::new(vec![1, 2, 3])),
+        nbt!([B; 1, 2, 3]),
         Value::ByteArray(ByteArray::new(vec![1, 2, 3]))
     );
     assert_eq!(
-        nbt!(IntArray::new(vec![1, 2, 3])),
+        nbt!([I;1,2,3]),
         Value::IntArray(IntArray::new(vec![1, 2, 3]))
     );
     assert_eq!(
-        nbt!(LongArray::new(vec![1, 2, 3])),
+        nbt!([L; 1, 2, 3,]),
         Value::LongArray(LongArray::new(vec![1, 2, 3]))
     );
 }

--- a/fastnbt/src/test/macros.rs
+++ b/fastnbt/src/test/macros.rs
@@ -64,6 +64,9 @@ fn nbt() {
         ]))
     );
 
+    assert_eq!(nbt!([B;]), Value::ByteArray(ByteArray::new(vec![])));
+    assert_eq!(nbt!([I;]), Value::IntArray(IntArray::new(vec![])));
+    assert_eq!(nbt!([L;]), Value::LongArray(LongArray::new(vec![])));
     assert_eq!(
         nbt!([B; 1, 2, 3]),
         Value::ByteArray(ByteArray::new(vec![1, 2, 3]))

--- a/fastnbt/src/test/macros.rs
+++ b/fastnbt/src/test/macros.rs
@@ -14,6 +14,8 @@ fn nbt() {
     assert_eq!(nbt!(1_u64), Value::Long(1));
     assert_eq!(nbt!(1_f32), Value::Float(1.0));
     assert_eq!(nbt!(1.0), Value::Double(1.0));
+    assert_eq!(nbt!(true), Value::Byte(1));
+    assert_eq!(nbt!(false), Value::Byte(0));
 
     assert_eq!(nbt!("string"), Value::String("string".to_owned()));
     assert_eq!(

--- a/fastnbt/src/test/macros.rs
+++ b/fastnbt/src/test/macros.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use crate::Value;
+
+#[test]
+fn nbt() {
+    assert_eq!(nbt!(1_i8), Value::Byte(1));
+    assert_eq!(nbt!(1_u8), Value::Byte(1));
+    assert_eq!(nbt!(1_i16), Value::Short(1));
+    assert_eq!(nbt!(1_u16), Value::Short(1));
+    assert_eq!(nbt!(1), Value::Int(1));
+    assert_eq!(nbt!(1_u32), Value::Int(1));
+    assert_eq!(nbt!(1_i64), Value::Long(1));
+    assert_eq!(nbt!(1_u64), Value::Long(1));
+    assert_eq!(nbt!(1_f32), Value::Float(1.0));
+    assert_eq!(nbt!(1.0), Value::Double(1.0));
+
+    assert_eq!(nbt!("string"), Value::String("string".to_owned()));
+    assert_eq!(
+        nbt!("string".to_owned()),
+        Value::String("string".to_owned())
+    );
+
+    assert_eq!(nbt!([]), Value::List(vec![]));
+    assert_eq!(
+        nbt!([1, 3]),
+        Value::List(vec![Value::Int(1), Value::Int(3)])
+    );
+    assert_eq!(
+        nbt!([
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            "Duis mattis massa metus, vel consequat lacus tincidunt ut.",
+            "Nam in lobortis quam, vel vehicula magna.",
+            "Cras massa turpis, facilisis non volutpat vitae, elementum.",
+        ]),
+        Value::List(vec![
+            Value::String("Lorem ipsum dolor sit amet, consectetur adipiscing elit.".to_owned()),
+            Value::String("Duis mattis massa metus, vel consequat lacus tincidunt ut.".to_owned()),
+            Value::String("Nam in lobortis quam, vel vehicula magna.".to_owned()),
+            Value::String("Cras massa turpis, facilisis non volutpat vitae, elementum.".to_owned()),
+        ])
+    );
+
+    assert_eq!(nbt!({}), Value::Compound(HashMap::new()));
+    assert_eq!(
+        nbt!({ "key": "value" }),
+        Value::Compound(HashMap::from([(
+            "key".to_owned(),
+            Value::String("value".to_owned())
+        ),]))
+    );
+    assert_eq!(
+        nbt!({
+            "key1": "value1",
+            "key2": 42,
+            "key3": [4, 2],
+        }),
+        Value::Compound(HashMap::from([
+            ("key1".to_owned(), Value::String("value1".to_owned())),
+            ("key2".to_owned(), Value::Int(42)),
+            ("key3".to_owned(), Value::List(vec![Value::Int(4), Value::Int(2)])),
+        ]))
+    );
+}

--- a/fastnbt/src/test/macros.rs
+++ b/fastnbt/src/test/macros.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::Value;
+use crate::{Value, ByteArray, IntArray, LongArray};
 
 #[test]
 fn nbt() {
@@ -60,5 +60,18 @@ fn nbt() {
             ("key2".to_owned(), Value::Int(42)),
             ("key3".to_owned(), Value::List(vec![Value::Int(4), Value::Int(2)])),
         ]))
+    );
+
+    assert_eq!(
+        nbt!(ByteArray::new(vec![1, 2, 3])),
+        Value::ByteArray(ByteArray::new(vec![1, 2, 3]))
+    );
+    assert_eq!(
+        nbt!(IntArray::new(vec![1, 2, 3])),
+        Value::IntArray(IntArray::new(vec![1, 2, 3]))
+    );
+    assert_eq!(
+        nbt!(LongArray::new(vec![1, 2, 3])),
+        Value::LongArray(LongArray::new(vec![1, 2, 3]))
     );
 }

--- a/fastnbt/src/test/mod.rs
+++ b/fastnbt/src/test/mod.rs
@@ -17,6 +17,7 @@ mod minecraft_chunk;
 mod resources;
 mod ser;
 mod stream;
+mod macros;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 struct Single<T: Serialize> {

--- a/fastnbt/src/value.rs
+++ b/fastnbt/src/value.rs
@@ -472,3 +472,38 @@ partialeq_numeric! {
     eq_u64[u8 u16 u32 u64 usize]
     eq_f64[f32 f64]
 }
+
+macro_rules! from {
+    ($type:ty, $variant:ident $(, $($part:tt)+)?) => {
+        impl From<$type> for Value {
+            fn from(val: $type) -> Self {
+                Self::$variant(val$($($part)+)?)
+            }
+        }
+        impl From<&$type> for Value {
+            fn from(val: &$type) -> Self {
+                Self::$variant(val.to_owned()$($($part)+)?)
+            }
+        }
+    };
+}
+from!(i8, Byte);
+from!(u8, Byte, as i8);
+from!(i16, Short);
+from!(u16, Short, as i16);
+from!(i32, Int);
+from!(u32, Int, as i32);
+from!(i64, Long);
+from!(u64, Long, as i64);
+from!(f32, Float);
+from!(f64, Double);
+from!(String, String);
+from!(&str, String, .to_owned());
+from!(ByteArray, ByteArray);
+from!(IntArray, IntArray);
+from!(LongArray, LongArray);
+
+pub fn to_value<T>(value: T) -> Value
+where Value: From<T> {
+    Value::from(value)
+}

--- a/fastnbt/src/value.rs
+++ b/fastnbt/src/value.rs
@@ -503,6 +503,17 @@ from!(ByteArray, ByteArray);
 from!(IntArray, IntArray);
 from!(LongArray, LongArray);
 
+impl From<bool> for Value {
+    fn from(val: bool) -> Self {
+        Self::Byte(if val { 1 } else { 0 })
+    }
+}
+impl From<&bool> for Value {
+    fn from(val: &bool) -> Self {
+        Self::Byte(if *val { 1 } else { 0 })
+    }
+}
+
 pub fn to_value<T>(value: T) -> Value
 where Value: From<T> {
     Value::from(value)


### PR DESCRIPTION
This adds a `nbt!` macro similar to the `json!` macro from [serde_json](https://github.com/serde-rs/json). The code is actually mostly copied from there, but modified for NBT.

An example usage might look like this:
```rs
nbt!({
    "Items": [
        {
            "tag": {},
            "id": "minecraft:axolotl_bucket",
            "Count": 1_u8,
            "Slot": 0_u8,
        },
        {
            "id": "minecraft:stick",
            "Count": 42_u8,
            "Slot": 1_u8,
        },
        {
            "id": "minecraft:stone",
            "Count": 64_u8,
            "Slot": 11_u8,
        },
    ]
})
```

I have taken the simple approach of turning expressions into `fastnbt::Value`s and implemented the `From<T>` trait for a few types (all number types, `String`, `&str`, `ByteArray`, `IntArray`, `LongArray`, and all their referenced versions). If you would like me to do it the `serde_json` way and implement a Serializer with `fastnbt::Value` as the target type, I can do that too. That would allow any type with the `Serialize` trait to be turned into a value.

I also added one simple test, but no documentation. You are free to do that in the way you like