### PR TITLE
Add 128-bit integer support

### DIFF
--- a/fastnbt/src/test/de.rs
+++ b/fastnbt/src/test/de.rs
@@ -181,9 +181,19 @@ fn i128_from_invalid_int_array() {
         .int_array_payload(&[1, 2, 3])
         .tag(Tag::End)
         .build();
-
     let v: Result<V> = from_bytes(payload.as_slice());
+    assert!(v.is_err());
 
+    // Although number of bytes is correct, won't be accepted
+    let payload = Builder::new()
+        .start_compound("object")
+        .tag(Tag::ByteArray)
+        .name("_i")
+        .int_payload(16)
+        .int_array_payload(&[1; 16])
+        .tag(Tag::End)
+        .build();
+    let v: Result<V> = from_bytes(payload.as_slice());
     assert!(v.is_err());
 }
 

--- a/fastnbt/src/test/de.rs
+++ b/fastnbt/src/test/de.rs
@@ -123,6 +123,71 @@ fn bool_from_none_integral() {
 }
 
 #[test]
+#[cfg(not(no_integer128))]
+fn i128_from_int_array() {
+    #[derive(Deserialize)]
+    struct V {
+        max: u128,
+        min: i128,
+        zero: i128,
+        counting: u128,
+    }
+
+    let payload = Builder::new()
+        .start_compound("object")
+        .tag(Tag::IntArray)
+        .name("max")
+        .int_payload(4)
+        // All bits are 1
+        .int_array_payload(&[u32::MAX as i32; 4])
+        .tag(Tag::IntArray)
+        .name("min")
+        .int_payload(4)
+        // Only first bit is 1
+        .int_array_payload(&[1 << 31, 0, 0, 0])
+        .tag(Tag::IntArray)
+        .name("zero")
+        .int_payload(4)
+        .int_array_payload(&[0; 4])
+        .tag(Tag::IntArray)
+        .name("counting")
+        .int_payload(4)
+        .int_array_payload(&[1, 2, 3, 4])
+        .tag(Tag::End)
+        .build();
+
+    let v: V = from_bytes(payload.as_slice()).unwrap();
+
+    assert_eq!(v.max, u128::MAX);
+    assert_eq!(v.min, i128::MIN);
+    assert_eq!(v.zero, 0);
+    // Calculated with: 1 << 96 | 2 << 64 | 3 << 32 | 4
+    assert_eq!(v.counting, 79228162551157825753847955460); 
+}
+
+#[test]
+#[cfg(not(no_integer128))]
+fn i128_from_invalid_int_array() {
+    #[derive(Deserialize)]
+    struct V {
+        _i: i128,
+    }
+
+    let payload = Builder::new()
+        .start_compound("object")
+        .tag(Tag::IntArray)
+        .name("_i")
+        .int_payload(3)
+        .int_array_payload(&[1, 2, 3])
+        .tag(Tag::End)
+        .build();
+
+    let v: Result<V> = from_bytes(payload.as_slice());
+
+    assert!(v.is_err());
+}
+
+#[test]
 fn simple_short_to_i16() -> Result<()> {
     #[derive(Deserialize)]
     struct V {


### PR DESCRIPTION
This PR adds support for (de)serializing `i128` and `u128` from/to NBT IntArrays of length 4. Minecraft always saves UUIDs as IntArrays with 4 entries which perfectly matches 128 bits.