### PR TITLE
Add (de)serializer to/from Value

### DIFF
--- a/fastnbt/src/error.rs
+++ b/fastnbt/src/error.rs
@@ -2,7 +2,7 @@
 use std::fmt::Display;
 
 /// Various errors that can occur during deserialization.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Error(String);
 
 /// Convenience type for Result.

--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -140,7 +140,7 @@ mod de_arrays;
 mod macros;
 
 pub use arrays::*;
-pub use value::{Value, to_value};
+pub use value::{from_value, to_value, Value};
 
 #[cfg(test)]
 mod test;

--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -132,15 +132,15 @@ pub mod de;
 pub mod error;
 pub mod ser;
 pub mod stream;
+pub mod value;
 
 mod arrays;
 mod de_arrays;
-mod value;
 #[macro_use]
 mod macros;
 
 pub use arrays::*;
-pub use value::*;
+pub use value::{Value, to_value};
 
 #[cfg(test)]
 mod test;

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -79,27 +79,27 @@ macro_rules! nbt_internal {
 
     // Next element is an array.
     (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
-        nbt!(@array [$($elems,)* nbt!([$($array)*])] $($rest)*)
+        nbt_internal!(@array [$($elems,)* nbt_internal!([$($array)*])] $($rest)*)
     };
 
     // Next element is a map.
     (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
-        nbt!(@array [$($elems,)* nbt!({$($map)*})] $($rest)*)
+        nbt_internal!(@array [$($elems,)* nbt_internal!({$($map)*})] $($rest)*)
     };
 
     // Next element is an expression followed by comma.
     (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
-        nbt!(@array [$($elems,)* nbt!($next),] $($rest)*)
+        nbt_internal!(@array [$($elems,)* nbt_internal!($next),] $($rest)*)
     };
 
     // Last element is an expression with no trailing comma.
     (@array [$($elems:expr,)*] $last:expr) => {
-        nbt!(@array [$($elems,)* nbt!($last)])
+        nbt_internal!(@array [$($elems,)* nbt_internal!($last)])
     };
 
     // Comma after the most recent element.
     (@array [$($elems:expr),*] , $($rest:tt)*) => {
-        nbt!(@array [$($elems,)*] $($rest)*)
+        nbt_internal!(@array [$($elems,)*] $($rest)*)
     };
 
     // Unexpected token after most recent element.
@@ -121,17 +121,17 @@ macro_rules! nbt_internal {
 
     // Next element is an expression followed by comma.
     (@int_array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
-        nbt!(@int_array [$($elems,)* $next,] $($rest)*)
+        nbt_internal!(@int_array [$($elems,)* $next,] $($rest)*)
     };
 
     // Last element is an expression with no trailing comma.
     (@int_array [$($elems:expr,)*] $last:expr) => {
-        nbt!(@int_array [$($elems,)* $last])
+        nbt_internal!(@int_array [$($elems,)* $last])
     };
 
     // Comma after the most recent element.
     (@int_array [$($elems:expr),*] , $($rest:tt)*) => {
-        nbt!(@int_array [$($elems,)*] $($rest)*)
+        nbt_internal!(@int_array [$($elems,)*] $($rest)*)
     };
 
     // Unexpected token after most recent element.
@@ -143,7 +143,7 @@ macro_rules! nbt_internal {
     // TT muncher for parsing the inside of an object {...}. Each entry is
     // inserted into the given map variable.
     //
-    // Must be invoked as: nbt!(@object $map () ($($tt)*) ($($tt)*))
+    // Must be invoked as: nbt_internal!(@object $map () ($($tt)*) ($($tt)*))
     //
     // We require two copies of the input tokens so that we can match on one
     // copy and trigger errors on the other copy.
@@ -155,7 +155,7 @@ macro_rules! nbt_internal {
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
         let _ = $object.insert(($($key)+).into(), $value);
-        nbt!(@object $object () ($($rest)*) ($($rest)*));
+        nbt_internal!(@object $object () ($($rest)*) ($($rest)*));
     };
 
     // Current entry followed by unexpected token.
@@ -170,35 +170,35 @@ macro_rules! nbt_internal {
 
     // Next value is an array.
     (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
-        nbt!(@object $object [$($key)+] (nbt!([$($array)*])) $($rest)*);
+        nbt_internal!(@object $object [$($key)+] (nbt_internal!([$($array)*])) $($rest)*);
     };
 
     // Next value is a map.
     (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
-        nbt!(@object $object [$($key)+] (nbt!({$($map)*})) $($rest)*);
+        nbt_internal!(@object $object [$($key)+] (nbt_internal!({$($map)*})) $($rest)*);
     };
 
     // Next value is an expression followed by comma.
     (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
-        nbt!(@object $object [$($key)+] (nbt!($value)) , $($rest)*);
+        nbt_internal!(@object $object [$($key)+] (nbt_internal!($value)) , $($rest)*);
     };
 
     // Last value is an expression with no trailing comma.
     (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
-        nbt!(@object $object [$($key)+] (nbt!($value)));
+        nbt_internal!(@object $object [$($key)+] (nbt_internal!($value)));
     };
 
     // Missing value for last entry. Trigger a reasonable error message.
     (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
         // "unexpected end of macro invocation"
-        nbt!();
+        nbt_internal!();
     };
 
     // Missing colon and value for last entry. Trigger a reasonable error
     // message.
     (@object $object:ident ($($key:tt)+) () $copy:tt) => {
         // "unexpected end of macro invocation"
-        nbt!();
+        nbt_internal!();
     };
 
     // Misplaced colon. Trigger a reasonable error message.
@@ -216,7 +216,7 @@ macro_rules! nbt_internal {
     // Key is fully parenthesized. This avoids clippy double_parens false
     // positives because the parenthesization may be necessary here.
     (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
-        nbt!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+        nbt_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
     };
 
     // Refuse to absorb colon token into key expression.
@@ -226,13 +226,13 @@ macro_rules! nbt_internal {
 
     // Munch a token into the current key.
     (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
-        nbt!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+        nbt_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
     };
 
     //////////////////////////////////////////////////////////////////////////
     // The main implementation.
     //
-    // Must be invoked as: nbt!($($json)+)
+    // Must be invoked as: nbt_internal!($($nbt)+)
     //////////////////////////////////////////////////////////////////////////
 
     ([B;]) => {
@@ -252,19 +252,19 @@ macro_rules! nbt_internal {
     };
 
     ([B; $($tt:tt)+ ]) => {
-        $crate::Value::ByteArray($crate::ByteArray::new(nbt!(@int_array [] $($tt)+)))
+        $crate::Value::ByteArray($crate::ByteArray::new(nbt_internal!(@int_array [] $($tt)+)))
     };
 
     ([I; $($tt:tt)+ ]) => {
-        $crate::Value::IntArray($crate::IntArray::new(nbt!(@int_array [] $($tt)+)))
+        $crate::Value::IntArray($crate::IntArray::new(nbt_internal!(@int_array [] $($tt)+)))
     };
 
     ([L; $($tt:tt)+ ]) => {
-        $crate::Value::LongArray($crate::LongArray::new(nbt!(@int_array [] $($tt)+)))
+        $crate::Value::LongArray($crate::LongArray::new(nbt_internal!(@int_array [] $($tt)+)))
     };
 
     ([ $($tt:tt)+ ]) => {
-        $crate::Value::List(nbt!(@array [] $($tt)+))
+        $crate::Value::List(nbt_internal!(@array [] $($tt)+))
     };
 
     ({}) => {
@@ -274,7 +274,7 @@ macro_rules! nbt_internal {
     ({ $($tt:tt)+ }) => {
         $crate::Value::Compound({
             let mut object = std::collections::HashMap::new();
-            nbt!(@object object () ($($tt)+) ($($tt)+));
+            nbt_internal!(@object object () ($($tt)+) ($($tt)+));
             object
         })
     };
@@ -297,7 +297,7 @@ macro_rules! nbt_expect_expr_comma {
     ($e:expr , $($tt:tt)*) => {};
 }
 
-// The json_internal macro above cannot invoke vec directly because it uses
+// The nbt_internal macro above cannot invoke vec directly because it uses
 // local_inner_macros. A vec invocation there would resolve to $crate::vec.
 // Instead invoke vec here outside of local_inner_macros.
 #[macro_export]

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -279,9 +279,9 @@ macro_rules! nbt_internal {
         })
     };
 
-    // Any value of T where fastnbt::Value: From<T>
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
     ($other:expr) => {
-        $crate::to_value($other)
+        $crate::to_value(&$other).unwrap()
     };
 }
 

--- a/fastnbt/src/test/value/de.rs
+++ b/fastnbt/src/test/value/de.rs
@@ -123,3 +123,24 @@ fn nested() {
 
     assert_eq!(expected, val);
 }
+
+#[test]
+fn no_root_compound() {
+    assert_eq!(Ok(128_u8), from_value(&nbt!(128_u8)));
+    assert_eq!(Ok('a'), from_value(&nbt!('a')));
+    assert_eq!(Ok("string".to_string()), from_value(&nbt!("string")));
+    assert_eq!(Ok(u128::MAX), from_value(&nbt!(u128::MAX)));
+    assert_eq!(
+        Ok(ByteArray::new(vec![1, 2, 3])),
+        from_value(&nbt!([B; 1, 2, 3]))
+    );
+    assert_eq!(
+        Ok(IntArray::new(vec![1, 2, 3])),
+        from_value(&nbt!([I; 1, 2, 3]))
+    );
+    assert_eq!(
+        Ok(LongArray::new(vec![1, 2, 3])),
+        from_value(&nbt!([L; 1, 2, 3]))
+    );
+    assert_eq!(Ok(vec![1, 2, 3, 4]), from_value(&nbt!([1, 2, 3, 4])));
+}

--- a/fastnbt/src/test/value/de.rs
+++ b/fastnbt/src/test/value/de.rs
@@ -1,0 +1,125 @@
+use std::borrow::Cow;
+
+use serde::Deserialize;
+
+use crate::{value::from_value, ByteArray, IntArray, LongArray};
+
+#[test]
+fn simple_types() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct V<'a> {
+        bool: bool,
+        i8: i8,
+        i16: i16,
+        i32: i32,
+        i64: i64,
+        u8: u8,
+        u16: u16,
+        u32: u32,
+        u64: u64,
+        f32: f32,
+        f64: f64,
+        char: char,
+        str: Cow<'a, str>,
+        string: String,
+    }
+
+    let val: V = from_value(&nbt!({
+        "bool": true,
+        "i8": i8::MAX,
+        "i16": i16::MAX,
+        "i32": i32::MAX,
+        "i64": i64::MAX,
+        "u8": u8::MAX,
+        "u16": u16::MAX,
+        "u32": u32::MAX,
+        "u64": u64::MAX,
+        "f32": f32::MAX,
+        "f64": f64::MAX,
+        "char": 'n',
+        "str": "str",
+        "string": "string",
+    }))
+    .unwrap();
+
+    let expected = V {
+        bool: true,
+        i8: i8::MAX,
+        i16: i16::MAX,
+        i32: i32::MAX,
+        i64: i64::MAX,
+        u8: u8::MAX,
+        u16: u16::MAX,
+        u32: u32::MAX,
+        u64: u64::MAX,
+        f32: f32::MAX,
+        f64: f64::MAX,
+        char: 'n',
+        str: "str".into(),
+        string: "string".to_string(),
+    };
+
+    assert_eq!(expected, val);
+    // A borrowed string cannot be deserialized from Value
+    assert!(matches!(val.str, Cow::Owned(_)));
+}
+
+#[test]
+fn int_array_types() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct V {
+        i128: i128,
+        u128: u128,
+        bytes: ByteArray,
+        ints: IntArray,
+        longs: LongArray,
+    }
+
+    let val = from_value(&nbt!({
+        "i128": i128::MAX,
+        "u128": u128::MAX,
+        "bytes": [B; 1, 2, 3, 4, 5],
+        "ints": [I; 1, 2, 3, 4, 5],
+        "longs": [L; 1, 2, 3, 4, 5],
+    }))
+    .unwrap();
+
+    let expected = V {
+        i128: i128::MAX,
+        u128: u128::MAX,
+        bytes: ByteArray::new(vec![1, 2, 3, 4, 5]),
+        ints: IntArray::new(vec![1, 2, 3, 4, 5]),
+        longs: LongArray::new(vec![1, 2, 3, 4, 5]),
+    };
+
+    assert_eq!(expected, val);
+}
+
+#[test]
+fn nested() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct V {
+        list: Vec<i16>,
+        nested: Inner,
+    }
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Inner {
+        key: u8,
+    }
+
+    let val = from_value(&nbt!({
+        "list": [1_i16, 2_i16],
+        "nested": {
+            "key": 42_u8,
+        },
+    }))
+    .unwrap();
+
+    let expected = V {
+        list: vec![1, 2],
+        nested: Inner { key: 42 },
+    };
+
+    assert_eq!(expected, val);
+}

--- a/fastnbt/src/test/value/mod.rs
+++ b/fastnbt/src/test/value/mod.rs
@@ -1,3 +1,6 @@
+mod ser;
+mod de;
+
 use std::collections::HashMap;
 
 use crate::{from_bytes, to_bytes, Tag, Value};

--- a/fastnbt/src/test/value/ser.rs
+++ b/fastnbt/src/test/value/ser.rs
@@ -148,3 +148,40 @@ fn nested() {
 
     assert_eq!(expected, val);
 }
+
+#[test]
+fn no_root_compound() {
+    assert_eq!(Ok(Value::Byte(-128)), to_value(-128_i8));
+    assert_eq!(Ok(Value::Int(97)), to_value('a'));
+    assert_eq!(Ok(Value::String("string".to_string())), to_value("string"));
+    assert_eq!(
+        Ok(Value::IntArray(IntArray::new(vec![u32::MAX as i32; 4]))),
+        to_value(u128::MAX)
+    );
+    assert_eq!(
+        Ok(Value::ByteArray(ByteArray::new(vec![1, 2, 3]))),
+        to_value(ByteArray::new(vec![1, 2, 3]))
+    );
+    assert_eq!(
+        Ok(Value::IntArray(IntArray::new(vec![1, 2, 3]))),
+        to_value(IntArray::new(vec![1, 2, 3]))
+    );
+    assert_eq!(
+        Ok(Value::LongArray(LongArray::new(vec![1, 2, 3]))),
+        to_value(LongArray::new(vec![1, 2, 3]))
+    );
+    assert_eq!(
+        Ok(Value::List(vec![
+            Value::Byte(1),
+            Value::Byte(2),
+            Value::Byte(3),
+            Value::Byte(4)
+        ])),
+        to_value(vec![
+            Value::Byte(1),
+            Value::Byte(2),
+            Value::Byte(3),
+            Value::Byte(4)
+        ])
+    );
+}

--- a/fastnbt/src/test/value/ser.rs
+++ b/fastnbt/src/test/value/ser.rs
@@ -1,0 +1,150 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+use crate::{to_value, ByteArray, IntArray, LongArray, Value};
+
+#[test]
+fn simple_types() {
+    #[derive(Serialize)]
+    struct V {
+        bool: bool,
+        i8: i8,
+        i16: i16,
+        i32: i32,
+        i64: i64,
+        u8: u8,
+        u16: u16,
+        u32: u32,
+        u64: u64,
+        f32: f32,
+        f64: f64,
+        char: char,
+        str: &'static str,
+        string: String,
+    }
+
+    let v = V {
+        bool: true,
+        i8: i8::MAX,
+        i16: i16::MAX,
+        i32: i32::MAX,
+        i64: i64::MAX,
+        u8: u8::MAX,
+        u16: u16::MAX,
+        u32: u32::MAX,
+        u64: u64::MAX,
+        f32: f32::MAX,
+        f64: f64::MAX,
+        char: 'n',
+        str: "value",
+        string: "value".to_string(),
+    };
+
+    let val = to_value(&v).unwrap();
+    // Note: we cannot use the nbt! macro here as that uses the `to_value` function
+    let expected = Value::Compound(HashMap::from([
+        ("bool".to_string(), Value::Byte(1)),
+        ("i8".to_string(), Value::Byte(i8::MAX)),
+        ("i16".to_string(), Value::Short(i16::MAX)),
+        ("i32".to_string(), Value::Int(i32::MAX)),
+        ("i64".to_string(), Value::Long(i64::MAX)),
+        ("u8".to_string(), Value::Byte(u8::MAX as i8)),
+        ("u16".to_string(), Value::Short(u16::MAX as i16)),
+        ("u32".to_string(), Value::Int(u32::MAX as i32)),
+        ("u64".to_string(), Value::Long(u64::MAX as i64)),
+        ("f32".to_string(), Value::Float(f32::MAX)),
+        ("f64".to_string(), Value::Double(f64::MAX)),
+        ("char".to_string(), Value::Int('n' as i32)),
+        ("str".to_string(), Value::String("value".to_string())),
+        ("string".to_string(), Value::String("value".to_string())),
+    ]));
+
+    assert_eq!(expected, val);
+}
+
+#[test]
+fn int_array_types() {
+    #[derive(Serialize)]
+    struct V {
+        i128: i128,
+        u128: u128,
+        bytes: ByteArray,
+        ints: IntArray,
+        longs: LongArray,
+    }
+
+    let v = V {
+        i128: i128::MAX,
+        u128: u128::MAX,
+        bytes: ByteArray::new(vec![1, 2, 3, 4, 5]),
+        ints: IntArray::new(vec![1, 2, 3, 4, 5]),
+        longs: LongArray::new(vec![1, 2, 3, 4, 5]),
+    };
+
+    let val = to_value(&v).unwrap();
+    let expected = Value::Compound(HashMap::from([
+        (
+            "i128".to_string(),
+            // Only left most bit is 0
+            Value::IntArray(IntArray::new(vec![
+                i32::MAX,
+                u32::MAX as i32,
+                u32::MAX as i32,
+                u32::MAX as i32,
+            ])),
+        ),
+        (
+            "u128".to_string(),
+            // All bits are 1
+            Value::IntArray(IntArray::new(vec![u32::MAX as i32; 4])),
+        ),
+        (
+            "bytes".to_string(),
+            Value::ByteArray(ByteArray::new(vec![1, 2, 3, 4, 5])),
+        ),
+        (
+            "ints".to_string(),
+            Value::IntArray(IntArray::new(vec![1, 2, 3, 4, 5])),
+        ),
+        (
+            "longs".to_string(),
+            Value::LongArray(LongArray::new(vec![1, 2, 3, 4, 5])),
+        ),
+    ]));
+
+    assert_eq!(expected, val);
+}
+
+#[test]
+fn nested() {
+    #[derive(Serialize)]
+    struct V {
+        list: Vec<i16>,
+        nested: Inner,
+    }
+
+    #[derive(Serialize)]
+    struct Inner {
+        key: u8,
+    }
+
+    let v = V {
+        list: vec![1, 2],
+        nested: Inner { key: 42 },
+    };
+
+    let val = to_value(&v).unwrap();
+    let expected = Value::Compound(HashMap::from([
+        (
+            "list".to_string(),
+            Value::List(vec![Value::Short(1), Value::Short(2)]),
+        ),
+        (
+            "nested".to_string(),
+            Value::Compound(HashMap::from([("key".to_string(), Value::Byte(42))])),
+        ),
+    ]));
+
+    assert_eq!(expected, val);
+}

--- a/fastnbt/src/value/array_serializer.rs
+++ b/fastnbt/src/value/array_serializer.rs
@@ -1,0 +1,194 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use serde::ser::Impossible;
+
+use crate::{error::Error, ByteArray, IntArray, LongArray, Tag, Value};
+
+use super::ser::Serializer;
+
+/// ArraySerializer is for serializing the NBT Arrays ie ByteArray, IntArray and
+/// LongArray.
+pub struct ArraySerializer<'a> {
+    pub ser: &'a mut Serializer,
+    pub tag: Tag,
+}
+
+impl<'a> serde::Serializer for ArraySerializer<'a> {
+    type Ok = Value;
+    type Error = Error;
+    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        match self.tag {
+            Tag::ByteArray => Ok(Value::ByteArray(ByteArray::from_bytes(v))),
+            Tag::IntArray => Ok(Value::IntArray(IntArray::new(
+                v.chunks_exact(4)
+                    .map(|mut bs| bs.read_i32::<LittleEndian>())
+                    .collect::<std::io::Result<Vec<i32>>>()?,
+            ))),
+            Tag::LongArray => Ok(Value::LongArray(LongArray::new(
+                v.chunks_exact(8)
+                    .map(|mut bs| bs.read_i64::<LittleEndian>())
+                    .collect::<std::io::Result<Vec<i64>>>()?,
+            ))),
+            _ => unreachable!(),
+        }
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        unimplemented!()
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        unimplemented!()
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        unimplemented!()
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        unimplemented!()
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        unimplemented!()
+    }
+}

--- a/fastnbt/src/value/array_serializer.rs
+++ b/fastnbt/src/value/array_serializer.rs
@@ -1,4 +1,4 @@
-use byteorder::{LittleEndian, ReadBytesExt};
+use byteorder::{NativeEndian, ReadBytesExt};
 use serde::ser::Impossible;
 
 use crate::{error::Error, ByteArray, IntArray, LongArray, Tag, Value};
@@ -80,12 +80,12 @@ impl<'a> serde::Serializer for ArraySerializer<'a> {
             Tag::ByteArray => Ok(Value::ByteArray(ByteArray::from_bytes(v))),
             Tag::IntArray => Ok(Value::IntArray(IntArray::new(
                 v.chunks_exact(4)
-                    .map(|mut bs| bs.read_i32::<LittleEndian>())
+                    .map(|mut bs| bs.read_i32::<NativeEndian>())
                     .collect::<std::io::Result<Vec<i32>>>()?,
             ))),
             Tag::LongArray => Ok(Value::LongArray(LongArray::new(
                 v.chunks_exact(8)
-                    .map(|mut bs| bs.read_i64::<LittleEndian>())
+                    .map(|mut bs| bs.read_i64::<NativeEndian>())
                     .collect::<std::io::Result<Vec<i64>>>()?,
             ))),
             _ => unreachable!(),

--- a/fastnbt/src/value/de.rs
+++ b/fastnbt/src/value/de.rs
@@ -1,11 +1,18 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
+use byteorder::BigEndian;
 use serde::{
-    de::{DeserializeSeed, Visitor},
-    Deserialize,
+    de::{
+        value::{BorrowedBytesDeserializer, BorrowedStrDeserializer},
+        DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess, SeqAccess, Unexpected,
+        VariantAccess, Visitor,
+    },
+    forward_to_deserialize_any, serde_if_integer128, Deserialize, Deserializer,
 };
 
-use crate::{ByteArray, IntArray, LongArray, Value};
+use crate::{error::Error, ByteArray, IntArray, LongArray, Value};
+
+use super::{INT_ARRAY_VALUE_TOKEN, LONG_ARRAY_VALUE_TOKEN};
 
 impl<'de> Deserialize<'de> for Value {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -110,13 +117,13 @@ impl<'de> Deserialize<'de> for Value {
                     }
                     Some(KeyClass::IntArray) => {
                         let data = map.next_value::<&[u8]>()?;
-                        IntArray::from_bytes(data)
+                        IntArray::from_bytes::<BigEndian>(data)
                             .map(Value::IntArray)
                             .map_err(|_| serde::de::Error::custom("could not read int array"))
                     }
                     Some(KeyClass::LongArray) => {
                         let data = map.next_value::<&[u8]>()?;
-                        LongArray::from_bytes(data)
+                        LongArray::from_bytes::<BigEndian>(data)
                             .map(Value::LongArray)
                             .map_err(|_| serde::de::Error::custom("could not read long array"))
                     }
@@ -179,5 +186,802 @@ impl<'de> Visitor<'de> for KeyClassifier {
             crate::LONG_ARRAY_TOKEN => Ok(KeyClass::LongArray),
             _ => Ok(KeyClass::Compound(s.to_string())),
         }
+    }
+}
+
+/* ---------- Deserializer ---------- */
+
+macro_rules! deserialize_number {
+    ($method:ident, $visit:ident, $primitive:ident, $variant:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self {
+                Value::$variant(v) => visitor.$visit(*v as $primitive),
+                _ => Err(self.invalid_type(&visitor)),
+            }
+        }
+    };
+}
+
+fn visit_list<'de, V>(list: &'de Vec<Value>, visitor: V) -> Result<V::Value, Error>
+where
+    V: Visitor<'de>,
+{
+    let len = list.len();
+    let mut deserializer = SeqDeserializer::new(list);
+    let seq = visitor.visit_seq(&mut deserializer)?;
+    let remaining = deserializer.iter.len();
+    if remaining == 0 {
+        Ok(seq)
+    } else {
+        Err(serde::de::Error::invalid_length(
+            len,
+            &"fewer elements in list",
+        ))
+    }
+}
+
+fn visit_compound<'de, V>(
+    compound: &'de HashMap<String, Value>,
+    visitor: V,
+) -> Result<V::Value, Error>
+where
+    V: Visitor<'de>,
+{
+    let len = compound.len();
+    let mut deserializer = MapDeserializer::new(compound);
+    let map = visitor.visit_map(&mut deserializer)?;
+    let remaining = deserializer.iter.len();
+    if remaining == 0 {
+        Ok(map)
+    } else {
+        Err(serde::de::Error::invalid_length(
+            len,
+            &"fewer elements in map",
+        ))
+    }
+}
+
+fn get_i128_value<'de>(de: &'de Value) -> Result<i128, Error> {
+    match de {
+        Value::IntArray(v) => {
+            if v.len() != 4 {
+                Err(Error::bespoke(format!(
+                    "deserialize i128: expected IntArray of length 4, got length {}",
+                    v.len()
+                )))
+            } else {
+                Ok(v.iter()
+                    .rev()
+                    .map(|n| (0..32).map(move |bit| n >> bit & 1))
+                    .flatten()
+                    .rev()
+                    .fold(0, |acc, bit| acc << 1 | bit as i128))
+            }
+        }
+        _ => Err(Error::bespoke(
+            "deserialize i128: expected IntArray value".to_string(),
+        )),
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for &'de Value {
+    type Error = Error;
+
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match *self {
+            Value::Byte(val) => visitor.visit_i8(val),
+            Value::Short(val) => visitor.visit_i16(val),
+            Value::Int(val) => visitor.visit_i32(val),
+            Value::Long(val) => visitor.visit_i64(val),
+            Value::Float(val) => visitor.visit_f32(val),
+            Value::Double(val) => visitor.visit_f64(val),
+            Value::String(ref val) => visitor.visit_borrowed_str(val),
+            Value::ByteArray(_) => visitor.visit_map(ArrayAccess {
+                token: crate::BYTE_ARRAY_TOKEN,
+                value: self,
+            }),
+            Value::IntArray(_) => visitor.visit_map(ArrayAccess {
+                token: crate::INT_ARRAY_TOKEN,
+                value: self,
+            }),
+            Value::LongArray(_) => visitor.visit_map(ArrayAccess {
+                token: crate::LONG_ARRAY_TOKEN,
+                value: self,
+            }),
+            Value::List(ref val) => visit_list(val, visitor),
+            Value::Compound(ref val) => visit_compound(val, visitor),
+        }
+    }
+
+    deserialize_number!(deserialize_i8, visit_i8, i8, Byte);
+    deserialize_number!(deserialize_i16, visit_i16, i16, Short);
+    deserialize_number!(deserialize_i32, visit_i32, i32, Int);
+    deserialize_number!(deserialize_i64, visit_i64, i64, Long);
+    deserialize_number!(deserialize_u8, visit_u8, u8, Byte);
+    deserialize_number!(deserialize_u16, visit_u16, u16, Short);
+    deserialize_number!(deserialize_u32, visit_u32, u32, Int);
+    deserialize_number!(deserialize_u64, visit_u64, u64, Long);
+    deserialize_number!(deserialize_f32, visit_f32, f32, Float);
+    deserialize_number!(deserialize_f64, visit_f64, f64, Double);
+
+    serde_if_integer128! {
+        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.visit_i128(get_i128_value(self)?)
+        }
+
+        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.visit_u128(get_i128_value(self)? as u128)
+        }
+    }
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(
+        self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (variant, value) = match self {
+            Value::Compound(value) => {
+                let mut iter = value.into_iter();
+                let (variant, value) = match iter.next() {
+                    Some(v) => v,
+                    None => {
+                        return Err(serde::de::Error::invalid_value(
+                            Unexpected::Map,
+                            &"map with a single key",
+                        ));
+                    }
+                };
+                // enums are encoded in nbt as maps with a single key:value pair
+                if iter.next().is_some() {
+                    return Err(serde::de::Error::invalid_value(
+                        Unexpected::Map,
+                        &"map with a single key",
+                    ));
+                }
+                (variant, Some(value))
+            }
+            Value::String(variant) => (variant, None),
+            other => {
+                return Err(serde::de::Error::invalid_type(
+                    other.unexpected(),
+                    &"string or map",
+                ));
+            }
+        };
+
+        visitor.visit_enum(EnumDeserializer { variant, value })
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match name {
+            crate::BYTE_ARRAY_TOKEN => visitor.visit_map(ArrayAccess {
+                token: name,
+                value: self,
+            }),
+            crate::INT_ARRAY_TOKEN => visitor.visit_map(ArrayAccess {
+                token: INT_ARRAY_VALUE_TOKEN,
+                value: self,
+            }),
+            crate::LONG_ARRAY_TOKEN => visitor.visit_map(ArrayAccess {
+                token: LONG_ARRAY_VALUE_TOKEN,
+                value: self,
+            }),
+            _ => return visitor.visit_newtype_struct(self),
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Byte(v) => visitor.visit_bool(v != &0),
+            Value::Short(v) => visitor.visit_bool(v != &0),
+            Value::Int(v) => visitor.visit_bool(v != &0),
+            Value::Long(v) => visitor.visit_bool(v != &0),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Int(v) => match char::from_u32(*v as u32) {
+                Some(v) => visitor.visit_char(v),
+                None => Err(serde::de::Error::invalid_value(
+                    self.unexpected(),
+                    &"invalid character code",
+                )),
+            },
+            Value::String(ref v) => match v.chars().next() {
+                Some(v) => visitor.visit_char(v),
+                None => Err(serde::de::Error::invalid_value(
+                    self.unexpected(),
+                    &"string contains no character",
+                )),
+            },
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::String(v) => visitor.visit_borrowed_str(v),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_byte_buf(visitor)
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::String(v) => visitor.visit_borrowed_str(v),
+            Value::List(v) => visit_list(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::List(v) => visit_list(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::Compound(v) => visit_compound(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self {
+            Value::List(v) => visit_list(v, visitor),
+            Value::Compound(v) => visit_compound(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_string(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        drop(self);
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+}
+
+pub struct ArrayAccess<'de> {
+    pub token: &'static str,
+    pub value: &'de Value,
+}
+impl<'de> MapAccess<'de> for ArrayAccess<'de> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        seed.deserialize(BorrowedStrDeserializer::new(self.token))
+            .map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let data = match self.value {
+            Value::ByteArray(v) => v.to_bytes(),
+            Value::IntArray(v) => v.to_bytes(),
+            Value::LongArray(v) => v.to_bytes(),
+            _ => unreachable!(),
+        };
+        let dz = BorrowedBytesDeserializer::new(data);
+        seed.deserialize(dz)
+    }
+}
+
+struct EnumDeserializer<'de> {
+    variant: &'de str,
+    value: Option<&'de Value>,
+}
+
+impl<'de> EnumAccess<'de> for EnumDeserializer<'de> {
+    type Error = Error;
+    type Variant = VariantDeserializer<'de>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = self.variant.into_deserializer();
+        let visitor = VariantDeserializer { value: self.value };
+        seed.deserialize(variant).map(|v| (v, visitor))
+    }
+}
+
+impl<'de> IntoDeserializer<'de, Error> for &'de Value {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+struct VariantDeserializer<'de> {
+    value: Option<&'de Value>,
+}
+
+impl<'de> VariantAccess<'de> for VariantDeserializer<'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Error> {
+        match self.value {
+            Some(value) => serde::Deserialize::deserialize(value),
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Some(Value::List(v)) => {
+                if v.is_empty() {
+                    visitor.visit_unit()
+                } else {
+                    visit_list(v, visitor)
+                }
+            }
+            Some(other) => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"tuple variant",
+            )),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Some(Value::Compound(v)) => visit_compound(v, visitor),
+            Some(other) => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"struct variant",
+            )),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}
+
+struct SeqDeserializer<'de> {
+    iter: std::slice::Iter<'de, Value>,
+}
+
+impl<'de> SeqDeserializer<'de> {
+    fn new(slice: &'de [Value]) -> Self {
+        SeqDeserializer { iter: slice.iter() }
+    }
+}
+
+impl<'de> SeqAccess<'de> for SeqDeserializer<'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapDeserializer<'de> {
+    iter: <&'de HashMap<String, Value> as IntoIterator>::IntoIter,
+    value: Option<&'de Value>,
+}
+
+impl<'de> MapDeserializer<'de> {
+    fn new(map: &'de HashMap<String, Value>) -> Self {
+        MapDeserializer {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for MapDeserializer<'de> {
+    type Error = Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                let key_de = MapKeyDeserializer {
+                    key: Cow::Borrowed(&**key),
+                };
+                seed.deserialize(key_de).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde::de::Error::custom("value is missing")),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapKeyDeserializer<'de> {
+    key: Cow<'de, str>,
+}
+
+macro_rules! deserialize_integer_key {
+    ($method:ident => $visit:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            match (self.key.parse(), self.key) {
+                (Ok(integer), _) => visitor.$visit(integer),
+                (Err(_), Cow::Borrowed(s)) => visitor.visit_borrowed_str(s),
+                (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
+            }
+        }
+    };
+}
+
+impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        BorrowedCowStrDeserializer::new(self.key).deserialize_any(visitor)
+    }
+
+    deserialize_integer_key!(deserialize_i8 => visit_i8);
+    deserialize_integer_key!(deserialize_i16 => visit_i16);
+    deserialize_integer_key!(deserialize_i32 => visit_i32);
+    deserialize_integer_key!(deserialize_i64 => visit_i64);
+    deserialize_integer_key!(deserialize_u8 => visit_u8);
+    deserialize_integer_key!(deserialize_u16 => visit_u16);
+    deserialize_integer_key!(deserialize_u32 => visit_u32);
+    deserialize_integer_key!(deserialize_u64 => visit_u64);
+
+    serde_if_integer128! {
+        deserialize_integer_key!(deserialize_i128 => visit_i128);
+        deserialize_integer_key!(deserialize_u128 => visit_u128);
+    }
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Map keys cannot be null.
+        visitor.visit_some(self)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.key
+            .into_deserializer()
+            .deserialize_enum(name, variants, visitor)
+    }
+
+    forward_to_deserialize_any! {
+        bool f32 f64 char str string bytes byte_buf unit unit_struct seq tuple
+        tuple_struct map struct identifier ignored_any
+    }
+}
+
+impl Value {
+    #[cold]
+    fn invalid_type<E>(&self, exp: &dyn Expected) -> E
+    where
+        E: serde::de::Error,
+    {
+        serde::de::Error::invalid_type(self.unexpected(), exp)
+    }
+
+    #[cold]
+    fn unexpected(&self) -> Unexpected {
+        match self {
+            Value::Byte(v) => Unexpected::Signed(*v as i64),
+            Value::Short(v) => Unexpected::Signed(*v as i64),
+            Value::Int(v) => Unexpected::Signed(*v as i64),
+            Value::Long(v) => Unexpected::Signed(*v),
+            Value::Float(v) => Unexpected::Float(*v as f64),
+            Value::Double(v) => Unexpected::Float(*v),
+            Value::String(v) => Unexpected::Str(v),
+            Value::ByteArray(_) => Unexpected::Seq,
+            Value::IntArray(_) => Unexpected::Seq,
+            Value::LongArray(_) => Unexpected::Seq,
+            Value::List(_) => Unexpected::Seq,
+            Value::Compound(_) => Unexpected::Map,
+        }
+    }
+}
+
+struct BorrowedCowStrDeserializer<'de> {
+    value: Cow<'de, str>,
+}
+
+impl<'de> BorrowedCowStrDeserializer<'de> {
+    fn new(value: Cow<'de, str>) -> Self {
+        BorrowedCowStrDeserializer { value }
+    }
+}
+
+impl<'de> Deserializer<'de> for BorrowedCowStrDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Cow::Borrowed(string) => visitor.visit_borrowed_str(string),
+            Cow::Owned(string) => visitor.visit_string(string),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_enum(self)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct identifier ignored_any
+    }
+}
+
+impl<'de> EnumAccess<'de> for BorrowedCowStrDeserializer<'de> {
+    type Error = Error;
+    type Variant = UnitOnly;
+
+    fn variant_seed<T>(self, seed: T) -> Result<(T::Value, Self::Variant), Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let value = seed.deserialize(self)?;
+        Ok((value, UnitOnly))
+    }
+}
+
+struct UnitOnly;
+
+impl<'de> VariantAccess<'de> for UnitOnly {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        Err(serde::de::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"newtype variant",
+        ))
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(serde::de::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"tuple variant",
+        ))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(serde::de::Error::invalid_type(
+            Unexpected::UnitVariant,
+            &"struct variant",
+        ))
     }
 }

--- a/fastnbt/src/value/de.rs
+++ b/fastnbt/src/value/de.rs
@@ -191,6 +191,37 @@ impl<'de> Visitor<'de> for KeyClassifier {
 
 /* ---------- Deserializer ---------- */
 
+//
+// Everything below is copied and modified from serde_json:
+// https://github.com/serde-rs/json/blob/52a9c050f5dcc0dc3de4825b131b8ff05219cc82/src/value/de.rs
+//
+// For which the license is MIT:
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
 macro_rules! deserialize_number {
     ($method:ident, $visit:ident, $primitive:ident, $variant:ident) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/fastnbt/src/value/de.rs
+++ b/fastnbt/src/value/de.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+
+use serde::{
+    de::{DeserializeSeed, Visitor},
+    Deserialize,
+};
+
+use crate::{ByteArray, IntArray, LongArray, Value};
+
+impl<'de> Deserialize<'de> for Value {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValueVisitor;
+        impl<'de> serde::de::Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("valid NBT")
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Byte(v))
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Short(v))
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Int(v))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Long(v))
+            }
+
+            fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Float(v))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::Double(v))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(Value::String(v.to_owned()))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                // I think I either need to do the same trick as I did for NBT
+                // Arrays and have dedicated types to this, or just accept that
+                // it's a Vec<Value> and that you can construct invalid NBT with
+                // it (by adding values of different type).
+
+                // Feel like the case of list of lists will break me if I try
+                // the dedicated type.
+                let mut v = Vec::<Value>::with_capacity(seq.size_hint().unwrap_or(0));
+
+                while let Some(el) = seq.next_element()? {
+                    v.push(el);
+                }
+
+                Ok(Value::List(v))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                match map.next_key_seed(KeyClassifier)? {
+                    Some(KeyClass::Compound(first_key)) => {
+                        let mut compound = HashMap::new();
+
+                        compound.insert(first_key, map.next_value()?);
+                        while let Some((key, value)) = map.next_entry()? {
+                            compound.insert(key, value);
+                        }
+
+                        Ok(Value::Compound(compound))
+                    }
+                    Some(KeyClass::ByteArray) => {
+                        let data = map.next_value::<&[u8]>()?;
+                        Ok(Value::ByteArray(ByteArray::from_bytes(data)))
+                    }
+                    Some(KeyClass::IntArray) => {
+                        let data = map.next_value::<&[u8]>()?;
+                        IntArray::from_bytes(data)
+                            .map(Value::IntArray)
+                            .map_err(|_| serde::de::Error::custom("could not read int array"))
+                    }
+                    Some(KeyClass::LongArray) => {
+                        let data = map.next_value::<&[u8]>()?;
+                        LongArray::from_bytes(data)
+                            .map(Value::LongArray)
+                            .map_err(|_| serde::de::Error::custom("could not read long array"))
+                    }
+                    // No keys just means an empty compound.
+                    None => Ok(Value::Compound(Default::default())),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+struct KeyClassifier;
+
+enum KeyClass {
+    Compound(String),
+    ByteArray,
+    IntArray,
+    LongArray,
+}
+
+impl<'de> DeserializeSeed<'de> for KeyClassifier {
+    type Value = KeyClass;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<KeyClass, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(self)
+    }
+}
+
+impl<'de> Visitor<'de> for KeyClassifier {
+    type Value = KeyClass;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("an nbt field string")
+    }
+
+    fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match s.as_str() {
+            crate::BYTE_ARRAY_TOKEN => Ok(KeyClass::ByteArray),
+            crate::INT_ARRAY_TOKEN => Ok(KeyClass::IntArray),
+            crate::LONG_ARRAY_TOKEN => Ok(KeyClass::LongArray),
+            _ => Ok(KeyClass::Compound(s)),
+        }
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match s {
+            crate::BYTE_ARRAY_TOKEN => Ok(KeyClass::ByteArray),
+            crate::INT_ARRAY_TOKEN => Ok(KeyClass::IntArray),
+            crate::LONG_ARRAY_TOKEN => Ok(KeyClass::LongArray),
+            _ => Ok(KeyClass::Compound(s.to_string())),
+        }
+    }
+}

--- a/fastnbt/src/value/mod.rs
+++ b/fastnbt/src/value/mod.rs
@@ -4,11 +4,14 @@ mod ser;
 
 use std::collections::HashMap;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{error::Error, ByteArray, IntArray, LongArray};
 
 pub use self::ser::Serializer;
+
+pub(crate) const INT_ARRAY_VALUE_TOKEN: &str = "__fastnbt_int_array_from_value";
+pub(crate) const LONG_ARRAY_VALUE_TOKEN: &str = "__fastnbt_long_array_from_value";
 
 /// Value is a complete NBT value. It owns its data. Compounds and Lists are
 /// resursively deserialized. This type takes care to preserve all the
@@ -379,4 +382,11 @@ where
     T: Serialize,
 {
     value.serialize(&mut Serializer)
+}
+
+pub fn from_value<'de, T>(value: &'de Value) -> Result<T, Error>
+where
+    T: Deserialize<'de>,
+{
+    T::deserialize(value)
 }

--- a/fastnbt/src/value/mod.rs
+++ b/fastnbt/src/value/mod.rs
@@ -1,11 +1,14 @@
+mod array_serializer;
+mod de;
+mod ser;
+
 use std::collections::HashMap;
 
-use serde::{
-    de::{DeserializeSeed, Visitor},
-    Deserialize, Serialize,
-};
+use serde::Serialize;
 
-use crate::{ByteArray, IntArray, LongArray};
+use crate::{error::Error, ByteArray, IntArray, LongArray};
+
+pub use self::ser::Serializer;
 
 /// Value is a complete NBT value. It owns its data. Compounds and Lists are
 /// resursively deserialized. This type takes care to preserve all the
@@ -154,203 +157,6 @@ impl Value {
         match self {
             Value::String(v) => Some(v),
             _ => None,
-        }
-    }
-}
-
-impl Serialize for Value {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Value::Byte(v) => serializer.serialize_i8(*v),
-            Value::Short(v) => serializer.serialize_i16(*v),
-            Value::Int(v) => serializer.serialize_i32(*v),
-            Value::Long(v) => serializer.serialize_i64(*v),
-            Value::Float(v) => serializer.serialize_f32(*v),
-            Value::Double(v) => serializer.serialize_f64(*v),
-            Value::String(v) => serializer.serialize_str(v),
-            Value::ByteArray(v) => v.serialize(serializer),
-            Value::IntArray(v) => v.serialize(serializer),
-            Value::LongArray(v) => v.serialize(serializer),
-            Value::List(v) => v.serialize(serializer),
-            Value::Compound(v) => v.serialize(serializer),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for Value {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct ValueVisitor;
-        impl<'de> serde::de::Visitor<'de> for ValueVisitor {
-            type Value = Value;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("valid NBT")
-            }
-
-            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Byte(v))
-            }
-
-            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Short(v))
-            }
-
-            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Int(v))
-            }
-
-            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Long(v))
-            }
-
-            fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Float(v))
-            }
-
-            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::Double(v))
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(Value::String(v.to_owned()))
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
-            {
-                // I think I either need to do the same trick as I did for NBT
-                // Arrays and have dedicated types to this, or just accept that
-                // it's a Vec<Value> and that you can construct invalid NBT with
-                // it (by adding values of different type).
-
-                // Feel like the case of list of lists will break me if I try
-                // the dedicated type.
-                let mut v = Vec::<Value>::with_capacity(seq.size_hint().unwrap_or(0));
-
-                while let Some(el) = seq.next_element()? {
-                    v.push(el);
-                }
-
-                Ok(Value::List(v))
-            }
-
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                match map.next_key_seed(KeyClassifier)? {
-                    Some(KeyClass::Compound(first_key)) => {
-                        let mut compound = HashMap::new();
-
-                        compound.insert(first_key, map.next_value()?);
-                        while let Some((key, value)) = map.next_entry()? {
-                            compound.insert(key, value);
-                        }
-
-                        Ok(Value::Compound(compound))
-                    }
-                    Some(KeyClass::ByteArray) => {
-                        let data = map.next_value::<&[u8]>()?;
-                        Ok(Value::ByteArray(ByteArray::from_bytes(data)))
-                    }
-                    Some(KeyClass::IntArray) => {
-                        let data = map.next_value::<&[u8]>()?;
-                        IntArray::from_bytes(data)
-                            .map(Value::IntArray)
-                            .map_err(|_| serde::de::Error::custom("could not read int array"))
-                    }
-                    Some(KeyClass::LongArray) => {
-                        let data = map.next_value::<&[u8]>()?;
-                        LongArray::from_bytes(data)
-                            .map(Value::LongArray)
-                            .map_err(|_| serde::de::Error::custom("could not read long array"))
-                    }
-                    // No keys just means an empty compound.
-                    None => Ok(Value::Compound(Default::default())),
-                }
-            }
-        }
-
-        deserializer.deserialize_any(ValueVisitor)
-    }
-}
-
-struct KeyClassifier;
-
-enum KeyClass {
-    Compound(String),
-    ByteArray,
-    IntArray,
-    LongArray,
-}
-
-impl<'de> DeserializeSeed<'de> for KeyClassifier {
-    type Value = KeyClass;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<KeyClass, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(self)
-    }
-}
-
-impl<'de> Visitor<'de> for KeyClassifier {
-    type Value = KeyClass;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("an nbt field string")
-    }
-
-    fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        match s.as_str() {
-            crate::BYTE_ARRAY_TOKEN => Ok(KeyClass::ByteArray),
-            crate::INT_ARRAY_TOKEN => Ok(KeyClass::IntArray),
-            crate::LONG_ARRAY_TOKEN => Ok(KeyClass::LongArray),
-            _ => Ok(KeyClass::Compound(s)),
-        }
-    }
-
-    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        match s {
-            crate::BYTE_ARRAY_TOKEN => Ok(KeyClass::ByteArray),
-            crate::INT_ARRAY_TOKEN => Ok(KeyClass::IntArray),
-            crate::LONG_ARRAY_TOKEN => Ok(KeyClass::LongArray),
-            _ => Ok(KeyClass::Compound(s.to_string())),
         }
     }
 }
@@ -514,7 +320,63 @@ impl From<&bool> for Value {
     }
 }
 
-pub fn to_value<T>(value: T) -> Value
-where Value: From<T> {
-    Value::from(value)
+/// Convert a `T` into `fastnbt::Value` which is an enum that can represent
+/// any valid NBT data.
+///
+/// # Example
+///
+/// ```
+/// use serde::Serialize;
+/// use fastnbt::nbt;
+///
+/// use std::error::Error;
+///
+/// #[derive(Serialize)]
+/// struct User {
+///     fingerprint: String,
+///     location: String,
+/// }
+///
+/// fn compare_nbt_values() -> Result<(), Box<dyn Error>> {
+///     let u = User {
+///         fingerprint: "0xF9BA143B95FF6D82".to_owned(),
+///         location: "Menlo Park, CA".to_owned(),
+///     };
+///
+///     // The type of `expected` is `fastnbt::Value`
+///     let expected = nbt!({
+///         "fingerprint": "0xF9BA143B95FF6D82",
+///         "location": "Menlo Park, CA",
+///     });
+///
+///     let v = fastnbt::to_value(u).unwrap();
+///     assert_eq!(v, expected);
+///
+///     Ok(())
+/// }
+/// #
+/// # compare_nbt_values().unwrap();
+/// ```
+///
+/// # Errors
+///
+/// This conversion can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+///
+/// ```
+/// use std::collections::BTreeMap;
+///
+/// fn main() {
+///     // The keys in this map are vectors, not strings.
+///     let mut map = BTreeMap::new();
+///     map.insert(vec![32, 64], "x86");
+///
+///     println!("{}", fastnbt::to_value(map).unwrap_err());
+/// }
+/// ```
+pub fn to_value<T>(value: T) -> Result<Value, Error>
+where
+    T: Serialize,
+{
+    value.serialize(&mut Serializer)
 }

--- a/fastnbt/src/value/ser.rs
+++ b/fastnbt/src/value/ser.rs
@@ -1,0 +1,620 @@
+use core::result;
+use std::collections::HashMap;
+
+use serde::{ser::Impossible, serde_if_integer128, Serialize};
+
+use crate::{
+    error::{Error, Result},
+    Value, IntArray, Tag,
+};
+
+use super::array_serializer::ArraySerializer;
+
+impl Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Value::Byte(v) => serializer.serialize_i8(*v),
+            Value::Short(v) => serializer.serialize_i16(*v),
+            Value::Int(v) => serializer.serialize_i32(*v),
+            Value::Long(v) => serializer.serialize_i64(*v),
+            Value::Float(v) => serializer.serialize_f32(*v),
+            Value::Double(v) => serializer.serialize_f64(*v),
+            Value::String(v) => serializer.serialize_str(v),
+            Value::ByteArray(v) => v.serialize(serializer),
+            Value::IntArray(v) => v.serialize(serializer),
+            Value::LongArray(v) => v.serialize(serializer),
+            Value::List(v) => v.serialize(serializer),
+            Value::Compound(v) => v.serialize(serializer),
+        }
+    }
+}
+
+// TODO: check licensing from serde_json
+/// Serializer whose output is a `Value`.
+///
+/// This is the serializer that backs [`fastnbt::to_value`][crate::to_value].
+/// Unlike the main fastnbt serializer which goes from some serializable
+/// value of type `T` to NBT bytes, this one goes from `T` to
+/// `fastnbt::Value`.
+///
+/// The `to_value` function is implementable as:
+///
+/// ```
+/// use serde::Serialize;
+/// use fastnbt::{error::Error, Value};
+///
+/// pub fn to_value<T>(input: T) -> Result<Value, Error>
+/// where
+///     T: Serialize,
+/// {
+///     input.serialize(&mut fastnbt::value::Serializer)
+/// }
+/// ```
+pub struct Serializer;
+
+impl <'a> serde::Serializer for &'a mut Serializer {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = SerializeVec;
+    type SerializeTuple = SerializeVec;
+    type SerializeTupleStruct = SerializeVec;
+    type SerializeTupleVariant = SerializeTupleVariant;
+    type SerializeMap = SerializeMap;
+    type SerializeStruct = SerializeMap;
+    type SerializeStructVariant = SerializeStructVariant;
+
+    #[inline]
+    fn serialize_bool(self, value: bool) -> Result<Value> {
+        Ok(Value::Byte(value as i8))
+    }
+
+    #[inline]
+    fn serialize_i8(self, value: i8) -> Result<Value> {
+        Ok(Value::Byte(value))
+    }
+
+    #[inline]
+    fn serialize_i16(self, value: i16) -> Result<Value> {
+        Ok(Value::Short(value))
+    }
+
+    #[inline]
+    fn serialize_i32(self, value: i32) -> Result<Value> {
+        Ok(Value::Int(value))
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Value> {
+        Ok(Value::Long(value))
+    }
+
+    serde_if_integer128! {
+        fn serialize_i128(self, v: i128) -> Result<Value> {
+            IntArray::new(vec![
+                (v >> 96) as i32,
+                (v >> 64) as i32,
+                (v >> 32) as i32,
+                v as i32,
+            ]).serialize(self)
+        }
+
+        fn serialize_u128(self, v: u128) -> Result<Value> {
+            self.serialize_i128(v as i128)
+        }
+    }
+
+    #[inline]
+    fn serialize_u8(self, value: u8) -> Result<Value> {
+        Ok(Value::Byte(value as i8))
+    }
+
+    #[inline]
+    fn serialize_u16(self, value: u16) -> Result<Value> {
+        Ok(Value::Short(value as i16))
+    }
+
+    #[inline]
+    fn serialize_u32(self, value: u32) -> Result<Value> {
+        Ok(Value::Int(value as i32))
+    }
+
+    #[inline]
+    fn serialize_u64(self, value: u64) -> Result<Value> {
+        Ok(Value::Long(value as i64))
+    }
+
+    #[inline]
+    fn serialize_f32(self, value: f32) -> Result<Value> {
+        Ok(Value::Float(value))
+    }
+
+    #[inline]
+    fn serialize_f64(self, value: f64) -> Result<Value> {
+        Ok(Value::Double(value))
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Value> {
+        Ok(Value::Int(value as i32))
+    }
+
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<Value> {
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Value> {
+        Ok(Value::List(
+            value.iter().map(|byte| Value::Byte(*byte as i8)).collect(),
+        ))
+    }
+
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Value> {
+        self.serialize_str(variant)
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        match variant {
+            crate::BYTE_ARRAY_TOKEN => {
+                value.serialize(ArraySerializer {
+                    ser: self,
+                    tag: Tag::ByteArray,
+                })
+            }
+            crate::INT_ARRAY_TOKEN => {
+                value.serialize(ArraySerializer {
+                    ser: self,
+                    tag: Tag::IntArray,
+                })
+            }
+            crate::LONG_ARRAY_TOKEN => {
+                value.serialize(ArraySerializer {
+                    ser: self,
+                    tag: Tag::LongArray,
+                })
+            }
+            _ => todo!("newtype variants that are not nbt arrays"),
+        }
+    }
+
+    #[inline]
+    fn serialize_some<T>(self, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(SerializeVec {
+            vec: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Ok(SerializeTupleVariant {
+            name: variant.into(),
+            vec: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(SerializeMap {
+            map: HashMap::new(),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Ok(SerializeStructVariant {
+            name: variant.into(),
+            map: HashMap::new(),
+        })
+    }
+
+    fn collect_str<T: ?Sized>(self, value: &T) -> Result<Value>
+    where
+        T: std::fmt::Display,
+    {
+        Ok(Value::String(value.to_string()))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok> {
+        todo!()
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok> {
+        todo!()
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
+        todo!()
+    }
+}
+
+pub struct SerializeVec {
+    vec: Vec<Value>,
+}
+
+pub struct SerializeTupleVariant {
+    name: String,
+    vec: Vec<Value>,
+}
+
+pub struct SerializeMap {
+    map: HashMap<String, Value>,
+    next_key: Option<String>,
+}
+
+pub struct SerializeStructVariant {
+    name: String,
+    map: HashMap<String, Value>,
+}
+
+impl serde::ser::SerializeSeq for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.vec.push(crate::to_value(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        Ok(Value::List(self.vec))
+    }
+}
+
+impl serde::ser::SerializeTuple for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+impl serde::ser::SerializeTupleStruct for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.vec.push(crate::to_value(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        let mut object = HashMap::new();
+
+        object.insert(self.name, Value::List(self.vec));
+
+        Ok(Value::Compound(object))
+    }
+}
+
+impl serde::ser::SerializeMap for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.next_key = Some(key.serialize(MapKeySerializer)?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let key = self.next_key.take();
+        // Panic because this indicates a bug in the program rather than an
+        // expected failure.
+        let key = key.expect("serialize_value called before serialize_key");
+        self.map.insert(key, crate::to_value(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        Ok(Value::Compound(self.map))
+    }
+}
+
+struct MapKeySerializer;
+
+fn key_must_be_a_string() -> Error {
+    Error::bespoke("Key must be a string".to_string())
+}
+
+impl serde::Serializer for MapKeySerializer {
+    type Ok = String;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<String, Error>;
+    type SerializeTuple = Impossible<String, Error>;
+    type SerializeTupleStruct = Impossible<String, Error>;
+    type SerializeTupleVariant = Impossible<String, Error>;
+    type SerializeMap = Impossible<String, Error>;
+    type SerializeStruct = Impossible<String, Error>;
+    type SerializeStructVariant = Impossible<String, Error>;
+
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<String> {
+        Ok(variant.to_owned())
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<String>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_bool(self, _value: bool) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_f32(self, _value: f32) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_f64(self, _value: f64) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<String> {
+        Ok(value.to_owned())
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit(self) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<String>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_none(self) -> Result<String> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<String>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(key_must_be_a_string())
+    }
+
+    fn collect_str<T: ?Sized>(self, value: &T) -> Result<String>
+    where
+        T: std::fmt::Display,
+    {
+        Ok(value.to_string())
+    }
+}
+
+impl serde::ser::SerializeStruct for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde::ser::SerializeMap::serialize_entry(self, key, value)
+    }
+
+    fn end(self) -> Result<Value> {
+        serde::ser::SerializeMap::end(self)
+    }
+}
+
+impl serde::ser::SerializeStructVariant for SerializeStructVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.map.insert(String::from(key), crate::to_value(&value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        let mut object = HashMap::new();
+
+        object.insert(self.name, Value::Compound(self.map));
+
+        Ok(Value::Compound(object))
+    }
+}

--- a/fastnbt/src/value/ser.rs
+++ b/fastnbt/src/value/ser.rs
@@ -5,7 +5,7 @@ use serde::{ser::Impossible, serde_if_integer128, Serialize};
 
 use crate::{
     error::{Error, Result},
-    Value, IntArray, Tag,
+    IntArray, Tag, Value,
 };
 
 use super::array_serializer::ArraySerializer;
@@ -32,7 +32,37 @@ impl Serialize for Value {
     }
 }
 
-// TODO: check licensing from serde_json
+//
+// Everything below is copied and modified from serde_json:
+// https://github.com/serde-rs/json/blob/52a9c050f5dcc0dc3de4825b131b8ff05219cc82/src/value/ser.rs
+//
+// For which the license is MIT:
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
 /// Serializer whose output is a `Value`.
 ///
 /// This is the serializer that backs [`fastnbt::to_value`][crate::to_value].
@@ -55,7 +85,7 @@ impl Serialize for Value {
 /// ```
 pub struct Serializer;
 
-impl <'a> serde::Serializer for &'a mut Serializer {
+impl<'a> serde::Serializer for &'a mut Serializer {
     type Ok = Value;
     type Error = Error;
 
@@ -181,24 +211,18 @@ impl <'a> serde::Serializer for &'a mut Serializer {
         T: ?Sized + Serialize,
     {
         match variant {
-            crate::BYTE_ARRAY_TOKEN => {
-                value.serialize(ArraySerializer {
-                    ser: self,
-                    tag: Tag::ByteArray,
-                })
-            }
-            crate::INT_ARRAY_TOKEN => {
-                value.serialize(ArraySerializer {
-                    ser: self,
-                    tag: Tag::IntArray,
-                })
-            }
-            crate::LONG_ARRAY_TOKEN => {
-                value.serialize(ArraySerializer {
-                    ser: self,
-                    tag: Tag::LongArray,
-                })
-            }
+            crate::BYTE_ARRAY_TOKEN => value.serialize(ArraySerializer {
+                ser: self,
+                tag: Tag::ByteArray,
+            }),
+            crate::INT_ARRAY_TOKEN => value.serialize(ArraySerializer {
+                ser: self,
+                tag: Tag::IntArray,
+            }),
+            crate::LONG_ARRAY_TOKEN => value.serialize(ArraySerializer {
+                ser: self,
+                tag: Tag::LongArray,
+            }),
             _ => todo!("newtype variants that are not nbt arrays"),
         }
     }


### PR DESCRIPTION
Another feature ported from `serde_json`:
- [x] Serializer from any serializable to `fastnbt::Value`
- [x] Deserializer from `fastnbt::Value` to any
- [x] Use the serializer instead of `From<T>` traits for `fastnbt::to_value` and `nbt!` macro
- [x] Resolve conflicts with #53 in case of merge