### PR TITLE
Remove unneeded Write bound from RegionIter

### DIFF
--- a/fastanvil/src/region.rs
+++ b/fastanvil/src/region.rs
@@ -358,7 +358,7 @@ pub struct ChunkData {
 
 impl<'a, S> Iterator for RegionIter<'a, S>
 where
-    S: Read + Write + Seek,
+    S: Read + Seek,
 {
     type Item = Result<ChunkData>;
 


### PR DESCRIPTION
This is blocking me from updating to the latest version.