### PR TITLE
Remove unused fastanvil dependency on hematite-nbt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,6 @@ dependencies = [
  "criterion",
  "fastnbt",
  "flate2",
- "hematite-nbt",
  "image",
  "log",
  "num_enum",
@@ -422,18 +421,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hematite-nbt"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670d0784ee67cfb57393dc1837867d2951f9a59ca7db99a653499c854f745739"
-dependencies = [
- "byteorder",
- "cesu8",
- "flate2",
- "serde",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/fastanvil/Cargo.toml
+++ b/fastanvil/Cargo.toml
@@ -17,7 +17,6 @@ bit_field = "0.10"
 serde = { version = "1.0", features= ["derive"] }
 log = "0.4"
 once_cell = "1.9"
-hematite-nbt = "0.5"
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
I noticed `hematite-nbt` in the list of compiled crates and was surprised, since `fastnbt` does roughly the same. Indeed, it seems to be unused - [cargo-udeps](https://crates.io/crates/cargo-udeps) agrees, and `rg "hematite"` doesn't find any mentions of it in the source code.
`cargo test` on the entire workspace passes both before and after the removal.

That dependency was added by https://github.com/owengage/fastnbt/commit/5151cddf3578cb79b2cbb96cf62cc4a3d0f7b884, a commit with no code changes that adds a benchmark comparing `fastnbt` and `hematite-nbt` to the readme, so possibly it was added by accident.