### PR TITLE
Add remove_chunk() to Region and tests

### DIFF
--- a/fastanvil/src/region.rs
+++ b/fastanvil/src/region.rs
@@ -25,6 +25,7 @@ pub(crate) const CHUNK_HEADER_SIZE: usize = 5;
 /// File). This does not concern itself with manipulating chunk data, users are
 /// expected to use `fastnbt` or other deserialization method to manipulate the
 /// chunk data itself.
+#[derive(Clone)]
 pub struct Region<S> {
     stream: S,
     // last offset is always the next valid place to write a chunk.
@@ -292,6 +293,25 @@ where
         ))?;
 
         self.stream.write_all(chunk)?;
+        Ok(())
+    }
+
+    pub fn remove_chunk(&mut self, x: usize, z: usize) -> Result<()> {
+        let loc = self.location(x, z)?;
+        // zero the region header for the chunk
+        self.set_header(x, z, 0, 0)?;
+
+        let i = self.offsets.binary_search(&loc.offset).unwrap();
+
+        // if the chunk's offset is the last the chunk is located at the end of the region and
+        // thereby the region can be truncated
+        if i + 1 >= self.offsets.len() {
+            // TODO: truncat the stream somehow
+        }
+
+        // remove the offset of the chunk
+        self.offsets.remove(i);
+
         Ok(())
     }
 

--- a/fastanvil/src/region.rs
+++ b/fastanvil/src/region.rs
@@ -166,8 +166,7 @@ where
     /// // manipulate region
     /// let mut file = region.into_inner()?;
     /// let len = file.stream_position()?;
-    /// file.truncate(len)?;
-    file.set_len(len)?;
+    /// file.set_len(len)?;
     /// # Ok(())
     /// # }
     ///  ```
@@ -185,7 +184,7 @@ where
         // up itself
         let chunk_length = self.stream.read_u32::<BigEndian>()? + 4;
         let logical_end = unstable_div_ceil(
-            offset as usize * SECTOR_SIZE as usize + chunk_length as usize,
+            offset as usize * SECTOR_SIZE + chunk_length as usize,
             SECTOR_SIZE,
         ) * SECTOR_SIZE;
 

--- a/fastanvil/src/region.rs
+++ b/fastanvil/src/region.rs
@@ -167,6 +167,7 @@ where
     /// let mut file = region.into_inner()?;
     /// let len = file.stream_position()?;
     /// file.truncate(len)?;
+    file.set_len(len)?;
     /// # Ok(())
     /// # }
     ///  ```

--- a/fastanvil/src/test/region.rs
+++ b/fastanvil/src/test/region.rs
@@ -236,6 +236,14 @@ fn into_inner_rewinds_to_correct_position() {
     assert_eq!(inner.position(), expected_position as u64);
 }
 
+#[test]
+fn into_inner_rewinds_behind_header_if_empty_region() {
+    let r = new_empty();
+
+    let inner = r.into_inner().unwrap();
+    assert_eq!(inner.position(), REGION_HEADER_SIZE as u64);
+}
+
 // TODO: Should we always zero out space? Would likely be good for compression.
 // TODO: defrag?
 


### PR DESCRIPTION
Unfortunately I did not find a way to truncate the buffer without having access to an underlying `File` or so.
Maybe add an `impl<File> Region` so we can use [`set_len`](https://doc.rust-lang.org/std/fs/struct.File.html#method.set_len)?

Note: I derived `Clone` on Region as the test `deleted_chunk_at_end_of_buffer_truncates_buffer` uses `into_inner` which consumes self. Please tell me if there's any better way to do so

PS: I'm pretty new to Rust so please don't hesitate to correct mistakes and improve the code :)