### PR TITLE
Chunk block iter

### DIFF
--- a/fastanvil/examples/iter-chunk-block.rs
+++ b/fastanvil/examples/iter-chunk-block.rs
@@ -18,15 +18,6 @@ fn main() {
         count += 1;
     }
 
-    println!("hot load {:?}", now.elapsed());
-
-    let now = Instant::now();
-    let mut count = 0;
-
-    for _ in ChunkBlockIter::new(&mut chunk) {
-        count += 1;
-    }
-
     println!("basic {:?}", now.elapsed());
 
     match chunk {

--- a/fastanvil/examples/iter-chunk-block.rs
+++ b/fastanvil/examples/iter-chunk-block.rs
@@ -1,0 +1,45 @@
+use std::time::Instant;
+
+use fastanvil::chunk_block_iter::CurrentChunkBlockIter;
+use fastanvil::{Chunk, JavaChunk, Region};
+
+fn main() {
+    let file = std::fs::File::open("./fastanvil/resources/r.0.0.mca").unwrap();
+
+    let mut region = Region::from_stream(file).unwrap();
+    let data = region.read_chunk(0, 0).unwrap().unwrap();
+
+    let chunk = JavaChunk::from_bytes(&data).unwrap();
+
+    match chunk {
+        JavaChunk::Post18(mut chunk) => {
+            let now = Instant::now();
+            let mut count = 0;
+
+            for _ in CurrentChunkBlockIter::new(&mut chunk) {
+                count += 1;
+            }
+
+            println!("{:?}", now.elapsed());
+            println!("{}", count);
+
+            let now = Instant::now();
+            let mut count = 0;
+
+            for x in 0..16 {
+                for z in 0..16 {
+                    for y in -64..320 {
+                        if chunk.block(x, y, z).is_some() {
+                            count += 1;
+                        }
+                    }
+                }
+            }
+
+            println!("{:?}", now.elapsed());
+            println!("{}", count);
+        }
+        JavaChunk::Pre18(_) => {}
+        JavaChunk::Pre13(_) => {}
+    }
+}

--- a/fastanvil/src/java/chunk_block_iter.rs
+++ b/fastanvil/src/java/chunk_block_iter.rs
@@ -1,0 +1,85 @@
+use crate::{Block, BlockData, CurrentJavaChunk, Section, SectionTower, StatesIter};
+
+pub struct CurrentChunkBlockIter<'a> {
+    section_tower: &'a SectionTower<Section>,
+    current_block_states: Option<&'a BlockData<Block>>,
+    current_section_iter: Option<StatesIter<'a>>,
+    next_y: isize,
+
+    blocks_to_fill: usize,
+}
+
+impl<'a> CurrentChunkBlockIter<'a> {
+    pub fn new(chunk: &'a mut CurrentJavaChunk) -> Self {
+        let mut thing = Self {
+            next_y: -64,
+            section_tower: chunk.sections.as_ref().unwrap(),
+            current_section_iter: None,
+            current_block_states: None,
+            blocks_to_fill: 0,
+        };
+
+        thing.init();
+
+        return thing;
+    }
+
+    fn init(&mut self) {
+
+        self.current_block_states = Some(
+            &self
+                .section_tower
+                .get_section_for_y(self.next_y)
+                .unwrap()
+                .block_states,
+        );
+
+        match self.current_block_states.unwrap().try_iter_indices() {
+            None => self.blocks_to_fill = 16 * 16 * 16,
+            Some(some) => self.current_section_iter = Some(some),
+        }
+
+        self.next_y += 16;
+    }
+}
+
+impl<'a> Iterator for CurrentChunkBlockIter<'a> {
+    type Item = Block;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.blocks_to_fill > 0 {
+            self.blocks_to_fill -= 1;
+
+            return Some(
+                self.current_block_states
+                    .unwrap()
+                    .palette()
+                    .get(0)
+                    .unwrap()
+                    .clone(),
+            );
+        }
+
+        return match self.current_section_iter.as_mut().unwrap().next() {
+            None => {
+                if self.next_y >= self.section_tower.y_max() {
+                    return None;
+                };
+
+                self.init();
+
+                self.next()
+            }
+            Some(index) => {
+                Some(
+                    self.current_block_states
+                        .unwrap()
+                        .palette()
+                        .get(index)
+                        .unwrap()
+                        .clone(),
+                )
+            }
+        }
+    }
+}

--- a/fastanvil/src/java/chunk_block_iter.rs
+++ b/fastanvil/src/java/chunk_block_iter.rs
@@ -1,4 +1,4 @@
-use crate::{Block, BlockData, CurrentJavaChunk, Section, SectionTower, StatesIter};
+use crate::{Block, BlockData, Chunk, CurrentJavaChunk, JavaChunk, Section, SectionTower, StatesIter};
 
 pub struct CurrentChunkBlockIter<'a> {
     section_tower: &'a SectionTower<Section>,
@@ -83,3 +83,51 @@ impl<'a> Iterator for CurrentChunkBlockIter<'a> {
         }
     }
 }
+
+
+pub struct ChunkBlockIter<'a> {
+    chunk: &'a JavaChunk,
+
+    x: usize,
+    y: isize,
+    z: usize,
+}
+
+impl<'a> ChunkBlockIter<'a> {
+    pub fn new(chunk: &'a mut JavaChunk) -> Self {
+        Self {
+            chunk,
+            x: 0,
+            y: -64,
+            z: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for ChunkBlockIter<'a> {
+    type Item = Block;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.x += 1;
+
+        if self.x >= 16 {
+            self.x = 0;
+            self.z += 1;
+
+            if self.z >= 16 {
+                self.z = 0;
+                self.y += 1;
+
+                if self.y >= 320 {
+                    return None;
+                }
+            }
+        }
+
+        return match self.chunk.block(self.x, self.y, self.z) {
+            None => None,
+            Some(block) => Some(block.clone()),
+        };
+    }
+}
+

--- a/fastanvil/src/java/chunk_block_iter.rs
+++ b/fastanvil/src/java/chunk_block_iter.rs
@@ -19,12 +19,12 @@ impl<'a> CurrentChunkBlockIter<'a> {
             blocks_to_fill: 0,
         };
 
-        thing.init();
+        thing.new_section();
 
         return thing;
     }
 
-    fn init(&mut self) {
+    fn new_section(&mut self) {
 
         self.current_block_states = Some(
             &self
@@ -47,6 +47,8 @@ impl<'a> Iterator for CurrentChunkBlockIter<'a> {
     type Item = Block;
 
     fn next(&mut self) -> Option<Self::Item> {
+
+        //check if in "empty" section
         if self.blocks_to_fill > 0 {
             self.blocks_to_fill -= 1;
 
@@ -62,11 +64,12 @@ impl<'a> Iterator for CurrentChunkBlockIter<'a> {
 
         return match self.current_section_iter.as_mut().unwrap().next() {
             None => {
+                //current section finished
                 if self.next_y >= self.section_tower.y_max() {
                     return None;
                 };
 
-                self.init();
+                self.new_section();
 
                 self.next()
             }

--- a/fastanvil/src/java/chunk_block_iter.rs
+++ b/fastanvil/src/java/chunk_block_iter.rs
@@ -1,4 +1,6 @@
-use crate::{Block, BlockData, Chunk, CurrentJavaChunk, JavaChunk, Section, SectionTower, StatesIter};
+use crate::{
+    Block, BlockData, Chunk, CurrentJavaChunk, JavaChunk, Section, SectionTower, StatesIter,
+};
 
 pub struct CurrentChunkBlockIter<'a> {
     section_tower: &'a SectionTower<Section>,
@@ -25,7 +27,6 @@ impl<'a> CurrentChunkBlockIter<'a> {
     }
 
     fn new_section(&mut self) {
-
         self.current_block_states = Some(
             &self
                 .section_tower
@@ -44,22 +45,14 @@ impl<'a> CurrentChunkBlockIter<'a> {
 }
 
 impl<'a> Iterator for CurrentChunkBlockIter<'a> {
-    type Item = Block;
+    type Item = &'a Block;
 
     fn next(&mut self) -> Option<Self::Item> {
-
         //check if in "empty" section
         if self.blocks_to_fill > 0 {
             self.blocks_to_fill -= 1;
 
-            return Some(
-                self.current_block_states
-                    .unwrap()
-                    .palette()
-                    .get(0)
-                    .unwrap()
-                    .clone(),
-            );
+            return Some(self.current_block_states.unwrap().palette().get(0).unwrap());
         }
 
         return match self.current_section_iter.as_mut().unwrap().next() {
@@ -73,20 +66,16 @@ impl<'a> Iterator for CurrentChunkBlockIter<'a> {
 
                 self.next()
             }
-            Some(index) => {
-                Some(
-                    self.current_block_states
-                        .unwrap()
-                        .palette()
-                        .get(index)
-                        .unwrap()
-                        .clone(),
-                )
-            }
-        }
+            Some(index) => Some(
+                self.current_block_states
+                    .unwrap()
+                    .palette()
+                    .get(index)
+                    .unwrap(),
+            ),
+        };
     }
 }
-
 
 pub struct ChunkBlockIter<'a> {
     chunk: &'a JavaChunk,
@@ -108,7 +97,7 @@ impl<'a> ChunkBlockIter<'a> {
 }
 
 impl<'a> Iterator for ChunkBlockIter<'a> {
-    type Item = Block;
+    type Item = &'a Block;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.x += 1;
@@ -129,8 +118,7 @@ impl<'a> Iterator for ChunkBlockIter<'a> {
 
         return match self.chunk.block(self.x, self.y, self.z) {
             None => None,
-            Some(block) => Some(block.clone()),
+            Some(block) => Some(block),
         };
     }
 }
-

--- a/fastanvil/src/java/mod.rs
+++ b/fastanvil/src/java/mod.rs
@@ -12,6 +12,7 @@ mod heightmaps;
 mod section;
 mod section_data;
 mod section_tower;
+pub mod chunk_block_iter;
 
 pub use block::*;
 pub use chunk::*;

--- a/fastanvil/src/java/mod.rs
+++ b/fastanvil/src/java/mod.rs
@@ -1,6 +1,17 @@
 use std::ops::Range;
 
+use once_cell::sync::Lazy;
+
+pub use block::*;
+pub use chunk::*;
 use fastnbt::{error::Result, from_bytes};
+pub use heightmaps::*;
+pub use section::*;
+pub use section_data::*;
+pub use section_tower::*;
+
+use crate::{biome::Biome, Chunk, HeightMode};
+
 /// 1.2 to 1.12
 pub mod pre13;
 /// 1.13 to 1.17
@@ -8,22 +19,11 @@ pub mod pre18;
 
 mod block;
 mod chunk;
+pub mod chunk_block_iter;
 mod heightmaps;
 mod section;
 mod section_data;
 mod section_tower;
-pub mod chunk_block_iter;
-
-pub use block::*;
-pub use chunk::*;
-pub use heightmaps::*;
-pub use section::*;
-pub use section_data::*;
-pub use section_tower::*;
-
-use once_cell::sync::Lazy;
-
-use crate::{biome::Biome, Chunk, HeightMode};
 
 pub static AIR: Lazy<Block> = Lazy::new(|| Block {
     name: "minecraft:air".to_owned(),


### PR DESCRIPTION
I tried creating a `chunk-block-iter` and honestly struggelt...
but i finaly got a pretty stupid version running for the `CurrentJavaChunk`... but the performance is questionable.

just a small warning this code is a mess. Dont worry it well get better.

---

`iter-chunk-blocks.rs` is a small exmaple (currently test) file. It containes 3 simple loops and messures very simple the performance. times on my machine with --release
- iter var1 - 12 ms
- iter var2 - 13 ms
- loop by hand - 1 ms

---

`chunk_block_iter.rs` contains 2 Iterators
 - the first tries to be more performent with the help of `try_iter_indices()`
    - theoretically could be performance wise improved (i think)
 - the second is very simple and just uses `block(x, y, z)`
     - would work with all chunk types
     
---

i dont know if i am using rusts Iterator Trait wrong but it feels like the performance overhead is to big.

maby i am also missing some major point to improve iter var1.
