### PR TITLE
Add optional feature for compound tags to preserve ordering

### DIFF
--- a/fastnbt/Cargo.toml
+++ b/fastnbt/Cargo.toml
@@ -14,11 +14,13 @@ categories = ["parser-implementations"]
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 byteorder = "1"
 cesu8 = "1.1"
+indexmap = { version = "1.9", optional = true, features = ["serde"] }
 serde = { version = "1", features=["derive"] }
 serde_bytes = "0.11.5"
 
 [features]
 arbitrary1 = ["arbitrary"]
+preserve-order = ["indexmap"]
 
 [dev-dependencies]
 flate2 = "1"

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -268,12 +268,12 @@ macro_rules! nbt_internal {
     };
 
     ({}) => {
-        $crate::Value::Compound(std::collections::HashMap::new())
+        $crate::Value::Compound($crate::value::CompoundMap::new())
     };
 
     ({ $($tt:tt)+ }) => {
         $crate::Value::Compound({
-            let mut object = std::collections::HashMap::new();
+            let mut object = $crate::value::CompoundMap::new();
             nbt_internal!(@object object () ($($tt)+) ($($tt)+));
             object
         })

--- a/fastnbt/src/test/fuzz.rs
+++ b/fastnbt/src/test/fuzz.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, iter::FromIterator};
+use std::iter::FromIterator;
 
-use crate::{error::Result, from_bytes, test::builder::Builder, Tag, Value};
+use crate::{error::Result, from_bytes, test::builder::Builder, Tag, Value, value::CompoundMap};
 
 /// Bugs found via cargo-fuzz.
 
@@ -29,7 +29,7 @@ fn float_double() {
     //           C   name  f  name  ............ end compound
     let input = [10, 0, 0, 5, 0, 0, 0, 0, 0, 10, 0];
     let v: Value = from_bytes(&input).unwrap();
-    let expected = Value::Compound(HashMap::from_iter([(
+    let expected = Value::Compound(CompoundMap::from_iter([(
         "".to_string(),
         Value::Float(1.4e-44),
     )]));

--- a/fastnbt/src/test/macros.rs
+++ b/fastnbt/src/test/macros.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use crate::{ByteArray, IntArray, LongArray, Value};
+use crate::{ByteArray, IntArray, LongArray, Value, value::CompoundMap};
 
 #[test]
 fn nbt() {
@@ -43,10 +41,10 @@ fn nbt() {
         ])
     );
 
-    assert_eq!(nbt!({}), Value::Compound(HashMap::new()));
+    assert_eq!(nbt!({}), Value::Compound(CompoundMap::new()));
     assert_eq!(
         nbt!({ "key": "value" }),
-        Value::Compound(HashMap::from([(
+        Value::Compound(CompoundMap::from([(
             "key".to_owned(),
             Value::String("value".to_owned())
         ),]))
@@ -57,7 +55,7 @@ fn nbt() {
             "key2": 42,
             "key3": [4, 2],
         }),
-        Value::Compound(HashMap::from([
+        Value::Compound(CompoundMap::from([
             ("key1".to_owned(), Value::String("value1".to_owned())),
             ("key2".to_owned(), Value::Int(42)),
             (

--- a/fastnbt/src/test/ser.rs
+++ b/fastnbt/src/test/ser.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, iter::FromIterator};
 use crate::{
     borrow, from_bytes,
     test::{resources::CHUNK_RAW_WITH_ENTITIES, Single, Wrap},
-    to_bytes, ByteArray, IntArray, LongArray, Tag, Value,
+    to_bytes, ByteArray, IntArray, LongArray, Tag, Value, value::CompoundMap,
 };
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use serde_bytes::{ByteBuf, Bytes};
@@ -452,7 +452,7 @@ fn nbt_long_array() {
 #[test]
 fn value_hashmap() {
     // let v = Value::Unit;
-    let v = Value::Compound(HashMap::from_iter([
+    let v = Value::Compound(CompoundMap::from_iter([
         ("a".to_string(), Value::Int(123)),
         ("b".to_string(), Value::Byte(123)),
     ]));

--- a/fastnbt/src/test/value/mod.rs
+++ b/fastnbt/src/test/value/mod.rs
@@ -1,9 +1,7 @@
 mod ser;
 mod de;
 
-use std::collections::HashMap;
-
-use crate::{from_bytes, to_bytes, Tag, Value};
+use crate::{from_bytes, to_bytes, Tag, Value, value::CompoundMap};
 
 use super::builder::Builder;
 
@@ -118,7 +116,7 @@ fn distinguish_floats() {
 #[test]
 fn fuzz_float() {
     let v = Value::Float(1.4e-44);
-    let mut inner = HashMap::new();
+    let mut inner = CompoundMap::new();
     inner.insert("".to_string(), v);
 
     let v = Value::Compound(inner);

--- a/fastnbt/src/value/de.rs
+++ b/fastnbt/src/value/de.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use serde::{
     de::{
@@ -11,6 +11,8 @@ use serde::{
 use serde_bytes::ByteBuf;
 
 use crate::{error::Error, ByteArray, IntArray, LongArray, Value};
+
+use super::CompoundMap;
 
 impl<'de> Deserialize<'de> for Value {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -100,7 +102,7 @@ impl<'de> Deserialize<'de> for Value {
             {
                 match map.next_key_seed(KeyClassifier)? {
                     Some(KeyClass::Compound(first_key)) => {
-                        let mut compound = HashMap::new();
+                        let mut compound = CompoundMap::new();
 
                         compound.insert(first_key, map.next_value()?);
                         while let Some((key, value)) = map.next_entry()? {
@@ -253,7 +255,7 @@ where
 }
 
 fn visit_compound<'de, V>(
-    compound: &'de HashMap<String, Value>,
+    compound: &'de CompoundMap,
     visitor: V,
 ) -> Result<V::Value, Error>
 where
@@ -735,12 +737,12 @@ impl<'de> SeqAccess<'de> for SeqDeserializer<'de> {
 }
 
 struct MapDeserializer<'de> {
-    iter: <&'de HashMap<String, Value> as IntoIterator>::IntoIter,
+    iter: <&'de CompoundMap as IntoIterator>::IntoIter,
     value: Option<&'de Value>,
 }
 
 impl<'de> MapDeserializer<'de> {
-    fn new(map: &'de HashMap<String, Value>) -> Self {
+    fn new(map: &'de CompoundMap) -> Self {
         MapDeserializer {
             iter: map.iter(),
             value: None,

--- a/fastnbt/src/value/mod.rs
+++ b/fastnbt/src/value/mod.rs
@@ -2,13 +2,27 @@ mod array_serializer;
 mod de;
 mod ser;
 
-use std::collections::HashMap;
-
 use serde::{serde_if_integer128, Deserialize, Serialize};
 
 use crate::{error::Error, ByteArray, IntArray, LongArray};
 
 pub use self::ser::Serializer;
+
+/// The [`String`] to [`Value`] map used by [`Value::Compound`].
+///
+/// Normally this type is a [`HashMap`](std::collections::HashMap). Enabling the
+/// **`preserve-order`** feature flag will replace it with an [`IndexMap`].
+///
+/// [`IndexMap`]: <https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html>
+#[cfg(not(feature = "preserve-order"))]
+pub type CompoundMap = std::collections::HashMap<String, Value>;
+
+/// The [`String`] to [`Value`] map used by [`Value::Compound`].
+///
+/// This type is currently an [`IndexMap`](indexmap::IndexMap). Disabling the **`preserve-order`**
+/// feature flag will replace it with a [`HashMap`](std::collections::HashMap).
+#[cfg(feature = "preserve-order")]
+pub type CompoundMap = indexmap::IndexMap<String, Value>;
 
 /// Value is a complete NBT value. It owns its data. Compounds and Lists are
 /// resursively deserialized. This type takes care to preserve all the
@@ -44,7 +58,7 @@ pub enum Value {
     IntArray(IntArray),
     LongArray(LongArray),
     List(Vec<Value>),
-    Compound(HashMap<String, Value>),
+    Compound(CompoundMap),
 }
 
 #[cfg(feature = "arbitrary1")]

--- a/fastnbt/src/value/ser.rs
+++ b/fastnbt/src/value/ser.rs
@@ -1,5 +1,4 @@
 use core::result;
-use std::collections::HashMap;
 
 use serde::{ser::Impossible, serde_if_integer128, Serialize};
 
@@ -9,7 +8,7 @@ use crate::{
     LONG_ARRAY_TOKEN,
 };
 
-use super::array_serializer::ArraySerializer;
+use super::{array_serializer::ArraySerializer, CompoundMap};
 
 impl Serialize for Value {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
@@ -275,7 +274,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
         Ok(SerializeMap {
-            map: HashMap::new(),
+            map: CompoundMap::new(),
             next_key: None,
         })
     }
@@ -293,7 +292,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     ) -> Result<Self::SerializeStructVariant> {
         Ok(SerializeStructVariant {
             name: variant.into(),
-            map: HashMap::new(),
+            map: CompoundMap::new(),
         })
     }
 
@@ -327,13 +326,13 @@ pub struct SerializeTupleVariant {
 }
 
 pub struct SerializeMap {
-    map: HashMap<String, Value>,
+    map: CompoundMap,
     next_key: Option<String>,
 }
 
 pub struct SerializeStructVariant {
     name: String,
-    map: HashMap<String, Value>,
+    map: CompoundMap,
 }
 
 impl serde::ser::SerializeSeq for SerializeVec {
@@ -398,7 +397,7 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     }
 
     fn end(self) -> Result<Value> {
-        let mut object = HashMap::new();
+        let mut object = CompoundMap::new();
 
         object.insert(self.name, Value::List(self.vec));
 
@@ -661,7 +660,7 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     }
 
     fn end(self) -> Result<Value> {
-        let mut object = HashMap::new();
+        let mut object = CompoundMap::new();
 
         object.insert(self.name, Value::Compound(self.map));
 

--- a/fuzz/fuzz_targets/deserialize_value.rs
+++ b/fuzz/fuzz_targets/deserialize_value.rs
@@ -1,17 +1,16 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use std::collections::HashMap;
-
 use fastnbt::error::Result;
 use fastnbt::to_bytes;
 use fastnbt::Value;
+use fastnbt::value::CompoundMap;
 use fastnbt::{from_bytes_with_opts, DeOpts};
 
 fuzz_target!(|data: &[u8]| {
     let value: Result<Value> = from_bytes_with_opts(data, DeOpts::new().max_seq_len(100));
     if let Ok(v) = value {
-        let mut wrapper = HashMap::new();
+        let mut wrapper = CompoundMap::new();
         wrapper.insert("wrapper".to_string(), v);
         let _bs = to_bytes(&Value::Compound(wrapper)).unwrap();
     }

--- a/fuzz/fuzz_targets/serialize_value.rs
+++ b/fuzz/fuzz_targets/serialize_value.rs
@@ -2,15 +2,15 @@
 use libfuzzer_sys::fuzz_target;
 
 use serde::Serialize;
-use std::collections::HashMap;
 
 use fastnbt::error::Result;
 use fastnbt::from_bytes;
 use fastnbt::to_bytes;
 use fastnbt::Value;
+use fastnbt::value::CompoundMap;
 
 fuzz_target!(|v: Value| {
-    let mut inner = HashMap::new();
+    let mut inner = CompoundMap::new();
     inner.insert("".to_string(), v);
 
     let v = Value::Compound(inner);


### PR DESCRIPTION
NBT data doesn't care about the order of tags, but having tags show up in a consistent order can be useful for debugging and exploring NBT data structures.

I've added a `preserve-order` feature to the `fastnbt` crate that replaces the `HashMap<String, Value>` in compound tags with an `IndexMap<String, Value>` using a type alias, which I named `CompoundMap`. I've also replaced all the relevant uses of `HashMap` with the alias, so everything works the same regardless of if the `preserve-order` feature is enabled.

These changes are completely non-breaking, since the only change when `preserve-order` is disabled is a new type alias.