### PR TITLE
Skip deleting non-existing chunks from a region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,9 +2346,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/fastanvil/src/test/region.rs
+++ b/fastanvil/src/test/region.rs
@@ -16,7 +16,7 @@ where
     let ChunkLocation {
         offset: found_offset,
         sectors: found_size,
-    } = r.location(x, z).unwrap();
+    } = r.location(x, z).unwrap().unwrap();
 
     assert_eq!(offset, found_offset);
     assert_eq!(size, found_size);

--- a/fastanvil/src/test/region.rs
+++ b/fastanvil/src/test/region.rs
@@ -220,6 +220,22 @@ fn deleted_chunk_doenst_exist() {
 }
 
 #[test]
+fn deleting_non_existing_chunk_works() {
+    let mut r = new_empty();
+
+    r.write_compressed_chunk(0, 0, Uncompressed, &n_sector_chunk(3))
+        .unwrap();
+    r.write_compressed_chunk(0, 2, Uncompressed, &n_sector_chunk(3))
+        .unwrap();
+
+    r.remove_chunk(0, 1).unwrap();
+
+    assert!(matches!(r.read_chunk(0, 0), Ok(Some(_))));
+    assert!(matches!(r.read_chunk(0, 1), Ok(None)));
+    assert!(matches!(r.read_chunk(0, 2), Ok(Some(_))));
+}
+
+#[test]
 fn into_inner_rewinds_to_correct_position() {
     let mut r = new_empty();
 


### PR DESCRIPTION
Also updates `Region::location` to integrate the non-existing check, making it less likely to forget to handle this case.

fixes #90 