### PR TITLE
Replace Fandom references with new wiki

### DIFF
--- a/fastanvil/examples/dump-mca.rs
+++ b/fastanvil/examples/dump-mca.rs
@@ -6,7 +6,7 @@ use fastnbt::Value;
 
 //
 // This loads an MCA file:
-// https://minecraft.fandom.com/wiki/Anvil_file_format#Further_information
+// https://minecraft.wiki/w/Anvil_file_format#Further_information
 //
 // This can be a region, a POI, or an entities MCA file, and dumps the value of it.
 //

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -28,7 +28,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 /// Produce a [`Value`][`crate::Value`] using
-/// JSON/[SNBT](https://minecraft.fandom.com/wiki/NBT_format#SNBT_format)-like
+/// JSON/[SNBT](https://minecraft.wiki/w/NBT_format#SNBT_format)-like
 /// syntax.
 ///
 /// Example:
@@ -45,7 +45,7 @@
 /// above could not be simplified to just `key1`.
 ///
 /// NBT Arrays are supported with
-/// [SNBT](https://minecraft.fandom.com/wiki/NBT_format#SNBT_format) syntax:
+/// [SNBT](https://minecraft.wiki/w/NBT_format#SNBT_format) syntax:
 ///
 /// ```rust
 /// # use fastnbt::nbt;

--- a/fastnbt/src/ser/serializer.rs
+++ b/fastnbt/src/ser/serializer.rs
@@ -563,7 +563,7 @@ impl<'a, W: 'a + Write> serde::ser::Serializer for &'a mut Delayed<'a, W> {
             // relevant serialize call never happens.
 
             // This is talked about a bit here:
-            // https://minecraft.fandom.com/wiki/NBT_format
+            // https://minecraft.wiki/w/NBT_format
             // A list of end tags seems to be the way to go.
 
             self.ser.writer.write_tag(Tag::End)?;


### PR DESCRIPTION
See [here](https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom) for details