### PR TITLE
Update Gamepedia wiki links to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ fn main() {
 # Example: print player inventory
 
 This example demonstrates printing out a players inventory and ender chest contents from the [player dat
-files](https://minecraft.gamepedia.com/Player.dat_format) found in worlds. We
+files](https://minecraft.wiki/w/Player.dat_format) found in worlds. We
 
 - use serde's renaming attribute to have rustfmt conformant field names,
 - use lifetimes to save on string allocations, and

--- a/fastanvil/src/biome.rs
+++ b/fastanvil/src/biome.rs
@@ -3,7 +3,7 @@
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Deserializer};
 
-// Values from https://minecraft.gamepedia.com/Java_Edition_data_value#Biomes
+// Values from https://minecraft.wiki/w/Java_Edition_data_value#Biomes
 #[derive(TryFromPrimitive, IntoPrimitive, Debug, Clone, Copy, Eq, PartialEq)]
 #[repr(i32)] // i32 as in corresponding NBT.
 pub enum Biome {

--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -58,7 +58,7 @@
 //!
 //! This example demonstrates printing out a players inventory and ender chest
 //! contents from the [player dat
-//! files](https://minecraft.gamepedia.com/Player.dat_format) found in worlds.
+//! files](https://minecraft.wiki/w/Player.dat_format) found in worlds.
 //!
 //! Here we
 //! * use serde's renaming attributes to have rustfmt conformant field names,

--- a/fastnbt/src/stream.rs
+++ b/fastnbt/src/stream.rs
@@ -175,7 +175,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// ```
 /// ## Finding a heightmap
 /// Here we assume we've parsed up until we have entered the `Heightmaps` compound of the
-/// [Minecraft Anvil chunk format](https://minecraft.gamepedia.com/Chunk_format). We keep parsing until we find the
+/// [Minecraft Anvil chunk format](https://minecraft.wiki/w/Chunk_format). We keep parsing until we find the
 /// `WORLD_SURFACE` long array. We avoid entering nested compounds by skipping them if we enter one. We know we have
 /// finished with the current compound when we see the `CompoundEnd` value.
 ///

--- a/fastnbt/src/test/minecraft_chunk.rs
+++ b/fastnbt/src/test/minecraft_chunk.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 #[test]
 fn unit_variant_enum_for_chunk_status() {
-    // From https://minecraft.gamepedia.com/Chunk_format
+    // From https://minecraft.wiki/w/Chunk_format
     //
     //  Status: Defines the world generation status of this chunk. It is always
     //  one of the following: empty, structure_starts, structure_references,


### PR DESCRIPTION
This PR updates all Gamepedia, owned now by Fandom, urls accordingly.