### PR TITLE
Simplify `From<Tag> for u8` Implementation with Direct Cast

### DIFF
--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -214,21 +214,7 @@ impl TryFrom<u8> for Tag {
 
 impl From<Tag> for u8 {
     fn from(tag: Tag) -> Self {
-        match tag {
-            Tag::End => 0,
-            Tag::Byte => 1,
-            Tag::Short => 2,
-            Tag::Int => 3,
-            Tag::Long => 4,
-            Tag::Float => 5,
-            Tag::Double => 6,
-            Tag::ByteArray => 7,
-            Tag::String => 8,
-            Tag::List => 9,
-            Tag::Compound => 10,
-            Tag::IntArray => 11,
-            Tag::LongArray => 12,
-        }
+        tag as u8
     }
 }
 

--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -213,6 +213,7 @@ impl TryFrom<u8> for Tag {
 }
 
 impl From<Tag> for u8 {
+    #[inline(always)]
     fn from(tag: Tag) -> Self {
         tag as u8
     }

--- a/fastnbt/src/test/mod.rs
+++ b/fastnbt/src/test/mod.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use serde::{Deserialize, Serialize};
 
@@ -26,27 +26,31 @@ struct Single<T: Serialize> {
 #[derive(Serialize, Deserialize)]
 struct Wrap<T: Serialize>(T);
 
-fn assert_try_into(tag: Tag) {
-    assert_eq!(tag, (tag as u8).try_into().unwrap());
+macro_rules! check_tags {
+    {$($tag:ident = $val:literal),* $(,)?} => {
+        $(
+            assert_eq!(u8::from(Tag::$tag), $val);
+        )*
+    };
 }
 
 #[test]
 fn exhaustive_tag_check() {
-    use Tag::*;
-    assert_try_into(End);
-    assert_try_into(Byte);
-    assert_try_into(Short);
-    assert_try_into(Int);
-    assert_try_into(Long);
-    assert_try_into(Float);
-    assert_try_into(Double);
-    assert_try_into(ByteArray);
-    assert_try_into(String);
-    assert_try_into(List);
-    assert_try_into(Compound);
-    assert_try_into(Compound);
-    assert_try_into(IntArray);
-    assert_try_into(LongArray);
+    check_tags! {
+        End = 0,
+        Byte = 1,
+        Short = 2,
+        Int = 3,
+        Long = 4,
+        Float = 5,
+        Double = 6,
+        ByteArray = 7,
+        String = 8,
+        List = 9,
+        Compound = 10,
+        IntArray = 11,
+        LongArray = 12,
+    }
 
     for value in 13..=u8::MAX {
         assert!(Tag::try_from(value).is_err())


### PR DESCRIPTION
Refactored the `From<Tag>` implementation to utilize direct casting instead of a match expression.