### PR TITLE
Implement LZ4 decompression for 1.20.5+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "flate2",
  "image",
  "log",
+ "lz4-java-wrc",
  "num_enum",
  "once_cell",
  "serde",
@@ -533,6 +534,22 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lz4-java-wrc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed1c11dbd317fa5d0508cbb5ce47696bb27771e3c9604428e0e98c7c3d76d0d"
+dependencies = [
+ "lz4_flex",
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 
 [[package]]
 name = "memchr"
@@ -867,6 +884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +988,16 @@ dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/fastanvil/Cargo.toml
+++ b/fastanvil/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 fastnbt = { path = "../fastnbt", version = "2" }
 flate2 = "1.0"
+lz4-java-wrc = "0.2.0"
 num_enum = "0.5"
 byteorder = "1.3"
 bit_field = "0.10"


### PR DESCRIPTION
Close #101

At first I tried using `lz4_flex` directly, but that doesn't work because java uses a different format. Then I searched "lz4 java" in crates.io and I found this nice crate that implements exactly what we need.

We need a `Lz4DecoderWrapper` because the API of that crate is not the same as the gzip crates. This introduces an additional copy but I believe the only way to avoid that would be to change the interface of the `read_compressed_chunk` function.

Tested by generating a world using a server with `region-file-compression=lz4`, and using the `region-dump` binary to test decompressing it.