### PR TITLE
Add support for "network NBT"

### DIFF
--- a/fastnbt/src/de.rs
+++ b/fastnbt/src/de.rs
@@ -311,7 +311,11 @@ where
             let peek = self.input.consume_tag()?;
 
             match peek {
-                Tag::Compound => self.input.ignore_str()?,
+                Tag::Compound => {
+                    if self.opts.expect_coumpound_names {
+                        self.input.ignore_str()?
+                    }
+                }
                 _ => return Err(Error::no_root_compound()),
             }
 

--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -354,12 +354,20 @@ where
 pub struct DeOpts {
     /// Maximum number of bytes a list or array can be.
     max_seq_len: usize,
+    /// Whether compound tag names are expected to exist or not.
+    expect_coumpound_names: bool,
 }
 
 impl DeOpts {
     /// Create new options. This object follows a builder pattern.
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Creates a decoder for "network NBT" mode.
+    /// At the moment that consists compound tags not having names (or their length).
+    pub fn network_nbt() -> Self {
+        Self::new().expect_coumpound_names(false)
     }
 
     /// Set the maximum length any given sequence can be, eg lists. This does
@@ -369,12 +377,19 @@ impl DeOpts {
         self.max_seq_len = value;
         self
     }
+
+    /// Sets wheather the deserializer should expect compound tags to have names.
+    pub fn expect_coumpound_names(mut self, value: bool) -> Self {
+        self.expect_coumpound_names = value;
+        self
+    }
 }
 
 impl Default for DeOpts {
     fn default() -> Self {
         Self {
             max_seq_len: 10_000_000, // arbitrary high limit.
+            expect_coumpound_names: true,
         }
     }
 }


### PR DESCRIPTION
This adds support for post 1.20.2 networked NBT which doesn't encode compound tag names.
Pretty basic changes just adds a new deserialize option and a single if statement.

closes #103