### PR TITLE
Support rendering of short_grass in rendered_palette.rs

### DIFF
--- a/fastanvil/src/rendered_palette.rs
+++ b/fastanvil/src/rendered_palette.rs
@@ -74,7 +74,7 @@ impl Palette for RenderedPalette {
         // of the most called functions. Yuck.
         if let Some(id) = block.name().strip_prefix("minecraft:") {
             match id {
-                "grass" | "tall_grass" | "vine" | "fern" | "large_fern" => {
+                "grass" | "tall_grass" | "vine" | "fern" | "large_fern" | "short_grass" => {
                     return self.pick_grass(biome);
                 }
                 "grass_block" => {


### PR DESCRIPTION
This pull request updates the `rendered_palette.rs` file to add support for rendering the newly renamed "short_grass" block in the game.

**Changes:**
- Added `short_grass` to the pick_grass match case in `rendered_palette.rs` to rendering grasses.

**Motivation:**
The recent update in Minecraft version 1.20.3 Pre-Release 1 renamed "Grass" to "Short Grass". This necessitates our renderer to recognize and properly render the `short_grass` block. For more details on this update, please refer to the Minecraft Wiki: [Short Grass Update Details](https://minecraft.wiki/w/Short_Grass).
