### PR TITLE
Extend palette blocks support.

### DIFF
--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -301,6 +301,30 @@ pub fn make_palette(mc_jar_path: &Path) -> Result<()> {
             blockstate: Regex::new(r"minecraft:fire").unwrap(),
             texture_template: "minecraft:block/fire_0",
         },
+        RegexMapping {
+            blockstate: Regex::new(r"minecraft:pink_petals").unwrap(),
+            texture_template: "minecraft:block/pink_petals",
+        },
+        RegexMapping {
+            blockstate: Regex::new(r"minecraft:pointed_dripstone").unwrap(),
+            texture_template: "minecraft:block/pointed_dripstone_up_tip",
+        },
+        RegexMapping {
+            blockstate: Regex::new(r"minecraft:mangrove_roots").unwrap(),
+            texture_template: "minecraft:block/mangrove_roots_top",
+        },
+        RegexMapping {
+            blockstate: Regex::new(r"minecraft:(pumpkin|melon|attached_melon|attached_pumpkin|big_dripleaf)_stem").unwrap(),
+            texture_template: "minecraft:block/$1",
+        },
+        RegexMapping {
+            blockstate: Regex::new(r"minecraft:glow_lichen").unwrap(),
+            texture_template: "minecraft:block/glow_lichen",
+        },
+        RegexMapping {
+            blockstate: Regex::new(r"minecraft:composter").unwrap(),
+            texture_template: "minecraft:block/composter_top",
+        },
     ];
 
     let mut palette = HashMap::new();


### PR DESCRIPTION
## Description
This pull request adds support for specific blocks that are currently not handled properly due to unique blockstates. The changes include the addition of exception handlers when `make_palette`.

I'm not sure if my approach is the correct way to support new blocks. If my implementation is incorrect, please give me advice of the proper way to extend support for blocks with unique blockstates.

## Changes
Below are the detailed implementations proposed for two blocks, explaining the error causes and the solutions applied.

- **pink_petals**
  - **Error Description:** `Blockstate::Multipart` -> try_mappings
  - **Implementation:** Added RegexMapping to map `minecraft:block/pink_petals`.

- **pointed_dripstone**
  - **Error Description:** `Blockstate::Variants` -> renderer.get_top -> Variants::Single -> self.model_get_top -> el.faces.get("up").ok_or_else( || -> Error::MissingElements) -> try_mappings
  - **Implementation:** Added RegexMapping to map `minecraft:block/pointed_dripstone_up_tip`.

- **mangrove_roots**
  - **Error Description:** `Blockstate::Variants` -> renderer.get_top -> Variants::Single -> self.model_get_top -> el.faces.get("up").ok_or_else( || -> Error::MissingElements) -> try_mappings
  - **Implementation:** Added RegexMapping to map `minecraft:block/mangrove_roots_top`.

- **melon_stem**
  - **Error Description (Except mushroom_stem):** `Blockstate::Variants` -> renderer.get_top -> Variants::Single -> self.model_get_top -> el.faces.get("up").ok_or_else( || -> Error::MissingElements) -> try_mappings
  - **Implementation:** Added RegexMapping to map `minecraft:block/$1_stem_top`.
  - **Note:** Some of the stems work correctly (such as `stripped_warped_stem`), so I used a specific stem names to handle.
    - Correctly handled stems:
      - `stripped_warped_stem`
	  - `crimson_stem`
	  - `warped_stem`
	  - `stripped_crimson_stem`
	- Incorrectly handled stems:
	  - `pumpkin_stem`
	  - `melon_stem`
	  - `attached_melon_stem`
	  - `attached_pumpkin_stem`
	  - `big_dripleaf_stem`
	  - `mushroom_stem`

- **glow_lichen**
  - **Error Description:** `Blockstate::Multipart` -> try_mappings
  - **Implementation:** Added RegexMapping to map `minecraft:block/glow_lichen`.

- **composter**
  - **Error Description:** `Blockstate::Multipart` -> try_mappings
  - **Implementation:** Added RegexMapping to map `minecraft:block/composter_top`.

## Identified Mapping Issues for Minecraft 1.20.4

During testing with the Minecraft 1.20.4 world data, several blocks did not map correctly, potentially leading to incomplete or inaccurate renderings in generated maps. Here are some of the affected blocks and their respective counts from the process log:

- ~~"short_grass": 1105963,~~ (Support by #111)
- ~~"pink_petals": 52293,~~
- ~~"pointed_dripstone": 1000,~~
- ~~"mangrove_roots": 373,~~
- ~~"melon_stem": 249,~~
- "chest": 125, (Does not exist png in textures/block/)
- "white_bed": 58, (Does not exist png in textures/block/)
- "brown_wall_banner": 55, (Does not exist png in textures/block/)
- ~~"glow_lichen": 51,~~
- ~~"pumpkin_stem": 48,~~
- ~~"composter": 47,~~
- ~~"attached_pumpkin_stem": 47,~~
- "scaffolding": 38, (I don't know why this block can't be rendered. make_palette works correctly and find the correct texture.)
- "cave_vines_plant": 33,
- "light_blue_bed": 30, (Does not exist png in textures/block/)
- "redstone_wire": 30,
- "hopper": 29,
- "deepslate_tile_wall": 23,
- "powered_rail": 15,
- "grindstone": 15,
- "chorus_plant": 13,
- "cobweb": 12,
- "cave_vines": 12,
- ~~"attached_melon_stem": 10,~~
- "campfire": 9,
- "shulker_box": 9,
- "ladder": 9,
- ~~"big_dripleaf_stem": 8,~~
- "lever": 7,
- "blue_bed": 6, (Does not exist png in textures/block/)
- "stone_brick_wall": 5,
- "comparator": 5,
- "small_dripleaf": 4,
- "oak_door": 4,
- "orange_bed": 4, (Does not exist png in textures/block/)
- "dispenser": 4,
- "oak_sign": 4,
- "pink_bed": 4, (Does not exist png in textures/block/)
- "brewing_stand": 4,
- "mossy_stone_brick_wall": 3,
- "yellow_bed": 3, (Does not exist png in textures/block/)
- "lightning_rod": 3,
- "dropper": 3,
- "iron_bars": 3,
- "lime_shulker_box": 2,
- "white_shulker_box": 2,
- "observer": 2,
- "repeater": 2,
- "jungle_door": 2,
- "red_bed": 2, (Does not exist png in textures/block/)
- "white_banner": 2,
- "white_wall_banner": 1,
- "blue_shulker_box": 1,
- "ender_chest": 1,
- "red_shulker_box": 1,
- "dragon_wall_head": 1,
- "green_shulker_box": 1,
- "bamboo_button": 1,
- "sculk_sensor": 1,
- "calibrated_sculk_sensor": 1,
- "tripwire": 1,
- "spruce_door": 1