### PR TITLE
feat(fastnbt): add network nbt to serializer

### DIFF
--- a/fastnbt/src/lib.rs
+++ b/fastnbt/src/lib.rs
@@ -253,9 +253,20 @@ pub fn to_writer<T: Serialize, W: Write>(writer: W, v: &T) -> Result<()> {
 }
 
 /// Options for customizing serialization.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct SerOpts {
     root_name: String,
+    /// Whether to include the root compound name.
+    serialize_root_name: bool,
+}
+
+impl Default for SerOpts {
+    fn default() -> Self {
+        Self {
+            root_name: Default::default(),
+            serialize_root_name: true,
+        }
+    }
 }
 
 impl SerOpts {
@@ -264,11 +275,21 @@ impl SerOpts {
         Default::default()
     }
 
+    pub fn network_nbt() -> Self {
+        Self::new().serialize_root_compound_name(false)
+    }
+
+    pub fn serialize_root_compound_name(mut self, serialize_root_name: bool) -> Self {
+        self.serialize_root_name = serialize_root_name;
+        self
+    }
+
     /// Set the root name (top level) of the compound. In most Minecraft data
     /// structures this is the empty string. The [`ser`][`crate::ser`] module
     /// contains an example.
     pub fn root_name(mut self, root_name: impl Into<String>) -> Self {
         self.root_name = root_name.into();
+        self.serialize_root_name = true;
         self
     }
 }
@@ -281,6 +302,7 @@ pub fn to_bytes_with_opts<T: Serialize>(v: &T, opts: SerOpts) -> Result<Vec<u8>>
     let mut serializer = Serializer {
         writer: &mut result,
         root_name: opts.root_name,
+        serialize_root_name: opts.serialize_root_name,
     };
     v.serialize(&mut serializer)?;
     Ok(result)
@@ -293,6 +315,7 @@ pub fn to_writer_with_opts<T: Serialize, W: Write>(writer: W, v: &T, opts: SerOp
     let mut serializer = Serializer {
         writer,
         root_name: opts.root_name,
+        serialize_root_name: opts.serialize_root_name,
     };
     v.serialize(&mut serializer)?;
     Ok(())

--- a/fastnbt/src/test/ser.rs
+++ b/fastnbt/src/test/ser.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, io::Cursor, iter::FromIterator};
 
 use crate::{
-    borrow, from_bytes,
+    borrow, from_bytes, from_bytes_with_opts,
     test::{resources::CHUNK_RAW_WITH_ENTITIES, Single, Wrap},
-    to_bytes, to_bytes_with_opts, to_writer_with_opts, ByteArray, IntArray, LongArray, SerOpts,
-    Tag, Value,
+    to_bytes, to_bytes_with_opts, to_writer_with_opts, ByteArray, DeOpts, IntArray, LongArray,
+    SerOpts, Tag, Value,
 };
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use serde_bytes::{ByteBuf, Bytes};
@@ -935,4 +935,27 @@ fn serialize_root_with_name() {
     assert_eq!(actual_via_bytes, expected);
     assert_eq!(actual_via_writer.into_inner(), expected);
     assert_eq!(actual_value, expected);
+}
+
+#[test]
+fn serialize_networked_compound() {
+    #[derive(Serialize)]
+    struct Example {
+        networked: String,
+    }
+
+    let data = Example {
+        networked: "compound".to_string(),
+    };
+    let bytes: Vec<u8> = to_bytes_with_opts(&data, SerOpts::network_nbt()).unwrap();
+
+    assert_eq!(
+        bytes,
+        b"\
+        \x0a\
+            \x08\
+                \x00\x09networked\
+                \x00\x08compound\
+        \x00"
+    );
 }


### PR DESCRIPTION
This PR:
- Adds an extra param `serialize_root_name` to `SerOpts` along with helper methods.
- Gives extra functionality to a Serializer with `serialize_root_name` set to **false**.
- Adds a unit test to ensure it works.

Closes #114 