### PR TITLE
improve block API

### DIFF
--- a/fastanvil/src/java/block.rs
+++ b/fastanvil/src/java/block.rs
@@ -2,13 +2,6 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-#[derive(Debug, Clone)]
-pub struct Block {
-    pub(crate) name: String,
-    pub(crate) encoded: String,
-    pub(crate) archetype: BlockArchetype,
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub enum BlockArchetype {
     Normal,
@@ -17,44 +10,48 @@ pub enum BlockArchetype {
     Snowy,
 }
 
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub struct Block {
+    pub name: String,
+
+    #[serde(default)]
+    pub properties: HashMap<String, String>,
+}
+
 impl Block {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            properties: HashMap::new(),
+        }
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }
 
     pub fn snowy(&self) -> bool {
-        self.archetype == BlockArchetype::Snowy
+        self.properties.get("snowy").map(String::as_str) == Some("true")
+    }
+
+    pub fn archetype(&self) -> BlockArchetype {
+        if self.snowy() {
+            BlockArchetype::Snowy
+        } else if is_watery(&self.name) {
+            BlockArchetype::Watery
+        } else if is_airy(&self.name) {
+            BlockArchetype::Airy
+        } else {
+            BlockArchetype::Normal
+        }
     }
 
     /// A string of the format "id|prop1=val1,prop2=val2". The properties are
     /// ordered lexigraphically. This somewhat matches the way Minecraft stores
     /// variants in blockstates, but with the block ID/name prepended.
-    pub fn encoded_description(&self) -> &str {
-        &self.encoded
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "PascalCase")]
-struct BlockRaw {
-    name: String,
-
-    #[serde(default)]
-    properties: HashMap<String, String>,
-}
-
-impl<'de> Deserialize<'de> for Block {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let raw: BlockRaw = Deserialize::deserialize(deserializer)?;
-        let snowy = raw.properties.get("snowy").map(String::as_str) == Some("true");
-
-        let mut id = raw.name.clone() + "|";
-        let mut sep = "";
-
-        let mut props = raw
+    pub fn encoded_description(&self) -> String {
+        let mut props = self
             .properties
             .iter()
             .filter(|(k, _)| *k != "waterlogged") // TODO: Handle water logging. See note below
@@ -64,26 +61,13 @@ impl<'de> Deserialize<'de> for Block {
         // need to sort the properties for a consistent ID
         props.sort_unstable();
 
-        for (k, v) in props {
-            id = id + sep + k + "=" + v;
-            sep = ",";
-        }
+        let id = props
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(",");
 
-        let arch = if snowy {
-            BlockArchetype::Snowy
-        } else if is_watery(&raw.name) {
-            BlockArchetype::Watery
-        } else if is_airy(&raw.name) {
-            BlockArchetype::Airy
-        } else {
-            BlockArchetype::Normal
-        };
-
-        Ok(Self {
-            name: raw.name,
-            archetype: arch,
-            encoded: id,
-        })
+        format!("{}|{}", self.name.clone(), id)
     }
 }
 

--- a/fastanvil/src/java/mod.rs
+++ b/fastanvil/src/java/mod.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::{collections::HashMap, ops::Range};
 
 use fastnbt::{error::Result, from_bytes};
 /// 1.2 to 1.12
@@ -26,13 +26,11 @@ use crate::{biome::Biome, Chunk, HeightMode};
 
 pub static AIR: Lazy<Block> = Lazy::new(|| Block {
     name: "minecraft:air".to_owned(),
-    encoded: "minecraft:air|".to_owned(),
-    archetype: BlockArchetype::Airy,
+    properties: HashMap::new(),
 });
 pub static SNOW_BLOCK: Lazy<Block> = Lazy::new(|| Block {
     name: "minecraft:snow_block".to_owned(),
-    encoded: "minecraft:snow_block|".to_owned(),
-    archetype: BlockArchetype::Snowy,
+    properties: HashMap::new(),
 });
 
 /// A Minecraft chunk.

--- a/fastanvil/src/java/pre13/pre13_block_names.rs
+++ b/fastanvil/src/java/pre13/pre13_block_names.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{Block, BlockArchetype};
 
 macro_rules! coloured_block {
@@ -21,11 +23,7 @@ macro_rules! coloured_block {
             15 => "black",
             _ => unreachable!(),
         };
-        Block {
-            name: format!("minecraft:{col}_{}", $a),
-            encoded: format!("minecraft:{col}_{}|", $a),
-            archetype: BlockArchetype::Normal,
-        }
+        Block::new(format!("minecraft:{col}_{}", $a))
     }};
 }
 
@@ -41,9 +39,7 @@ pub fn init_default_block(block_id: u16, data_value: u8) -> Block {
 }
 
 fn modern_block(block_name: &'static str, data_value: u8) -> Block {
-    let encoded = format!("{}|", block_name);
     let ns = |s| format!("minecraft:{s}"); // add namespace
-    let enc0 = |s| format!("minecraft:{s}|");
 
     // This function will get very large and complicated, need some way to break
     // it down. Could definitely use some macros for things like the wood/leaf types.
@@ -61,10 +57,13 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 6 | 7 => "invalid_double_wooden_slab",
                 _ => unreachable!(),
             };
+
+            let mut properties = HashMap::new();
+            properties.insert("type".to_string(), "double".to_string());
+
             Block {
                 name: format!("{kind}_slab"),
-                encoded: format!("{kind}_slab|type=double"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
         "wooden_slab" => {
@@ -85,10 +84,13 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 1 => "top",
                 _ => unreachable!(),
             };
+
+            let mut properties = HashMap::new();
+            properties.insert("type".to_string(), top.to_string());
+
             Block {
                 name: format!("{kind}_slab"),
-                encoded: format!("{kind}_slab|type={top}"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
         "flower" => {
@@ -106,11 +108,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 9..=15 => "invalid_flower",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(kind),
-                encoded: enc0(kind),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(kind))
         }
         "red_sandstone" => {
             let kind = data_value & 0b0011;
@@ -121,11 +120,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 3 => "invalid_red_sandstone",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(kind),
-                encoded: enc0(kind),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(kind))
         }
         "sandstone" => {
             let kind = data_value & 0b0011;
@@ -136,11 +132,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 3 => "invalid_sandstone",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(kind),
-                encoded: enc0(kind),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(kind))
         }
         "double_stone_slab" => {
             let kind = data_value & 0b0111;
@@ -155,10 +148,13 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 7 => "quartz",
                 _ => unreachable!(),
             };
+
+            let mut properties = HashMap::new();
+            properties.insert("type".to_string(), "double".to_string());
+
             Block {
                 name: format!("{kind}_slab"),
-                encoded: format!("{kind}_slab|type=double"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
         "stone_slab" => {
@@ -180,17 +176,23 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 1 => "top",
                 _ => unreachable!(),
             };
+
+            let mut properties = HashMap::new();
+            properties.insert("type".to_string(), top.to_string());
             Block {
                 name: format!("{kind}_slab"),
-                encoded: format!("{kind}_slab|type={top}"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
-        "double_stone_slab2" => Block {
-            name: ns("red_sandstone_slab"),
-            encoded: enc0("red_sandstone_slab|type=double"),
-            archetype: BlockArchetype::Normal,
-        },
+        "double_stone_slab2" => {
+            let mut properties = HashMap::new();
+            properties.insert("type".to_string(), "double".to_string());
+
+            Block {
+                name: ns("red_sandstone_slab"),
+                properties,
+            }
+        }
         "stone_slab2" => {
             let top = data_value & 0b1000;
             let top = match top {
@@ -198,10 +200,12 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 8 => "top",
                 _ => unreachable!(),
             };
+
+            let mut properties = HashMap::new();
+            properties.insert("type".to_string(), top.to_string());
             Block {
                 name: ns("red_sandstone_slab"),
-                encoded: format!("red_sandstone_slab|type={top}"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
         "stained_glass" => {
@@ -220,11 +224,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 1 => "red_sand",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(kind),
-                encoded: enc0(kind),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(kind))
         }
         "sapling" => {
             let kind = data_value & 0b0111;
@@ -237,11 +238,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 5 => "dark_oak_sapling",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(kind),
-                encoded: enc0(kind),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(kind))
         }
         "dirt" => {
             let kind = data_value & 0b0011;
@@ -251,11 +249,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 2 => "podzol",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(kind),
-                encoded: enc0(kind),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(kind))
         }
         "stone" => {
             let kind = data_value & 0b0111;
@@ -269,11 +264,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 6 => "polished_andesite",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(kind),
-                encoded: enc0(kind),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(kind))
         }
         "leaves" => {
             let leaf = data_value & 0b0011;
@@ -284,11 +276,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 3 => "jungle_leaves",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(leaf),
-                encoded: enc0(leaf),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(leaf))
         }
         "leaves2" => {
             let leaf = data_value & 0b0011;
@@ -298,11 +287,8 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 2 | 3 => "invalid_leaves",
                 _ => unreachable!(),
             };
-            Block {
-                name: ns(leaf),
-                encoded: enc0(leaf),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(ns(leaf))
         }
         "log" => {
             let log = data_value & 0b0011;
@@ -321,10 +307,13 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 3 => "jungle_log",
                 _ => unreachable!(),
             };
+
+            let mut properties = HashMap::new();
+            properties.insert("axis".to_string(), axis.to_string());
+
             Block {
                 name: ns(log),
-                encoded: format!("minecraft:{log}|axis={axis}"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
         "log2" => {
@@ -343,18 +332,23 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 2 | 3 => "invalid_log",
                 _ => unreachable!(),
             };
+
+            let mut properties = HashMap::new();
+            properties.insert("axis".to_string(), axis.to_string());
+
             Block {
                 name: ns(log),
-                encoded: format!("minecraft:{log}|axis={axis}"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
         "snow_layer" => {
             let layers = (data_value & 0b0111) + 1;
+
+            let mut properties = HashMap::new();
+            properties.insert("layers".to_string(), layers.to_string());
             Block {
                 name: ns("snow"),
-                encoded: format!("minecraft:snow|layers={layers}"),
-                archetype: BlockArchetype::Normal,
+                properties,
             }
         }
         "stained_hardened_clay" => {
@@ -377,32 +371,13 @@ fn modern_block(block_name: &'static str, data_value: u8) -> Block {
                 15 => "black",
                 _ => unreachable!(),
             };
-            Block {
-                name: format!("minecraft:{col}_terracotta"),
-                encoded: format!("minecraft:{col}_terracotta|"),
-                archetype: BlockArchetype::Normal,
-            }
+
+            Block::new(format!("minecraft:{col}_terracotta"))
         }
-        "hardened_clay" => Block {
-            name: ns("terracotta"),
-            encoded,
-            archetype: BlockArchetype::Normal,
-        },
-        "tallgrass" => Block {
-            name: ns("tall_grass"),
-            encoded,
-            archetype: BlockArchetype::Normal,
-        },
-        "waterlily" => Block {
-            name: ns("lily_pad"),
-            encoded,
-            archetype: BlockArchetype::Normal,
-        },
-        _ => Block {
-            name: ns(block_name),
-            encoded,
-            archetype: BlockArchetype::Normal,
-        },
+        "hardened_clay" => Block::new(ns("terracotta")),
+        "tallgrass" => Block::new(ns("tall_grass")),
+        "waterlily" => Block::new(ns("lily_pad")),
+        _ => Block::new(ns(block_name)),
     }
 }
 

--- a/fastanvil/src/render.rs
+++ b/fastanvil/src/render.rs
@@ -35,7 +35,16 @@ impl<'a, P: Palette> TopShadeRenderer<'a, P> {
         let mut data = [[0, 0, 0, 0]; 16 * 16];
 
         let status = chunk.status();
-        const OK_STATUSES: [&str; 8] = ["full", "spawn", "postprocessed", "fullchunk", "minecraft:full", "minecraft:spawn", "minecraft:postprocessed", "minecraft:fullchunk"];
+        const OK_STATUSES: [&str; 8] = [
+            "full",
+            "spawn",
+            "postprocessed",
+            "fullchunk",
+            "minecraft:full",
+            "minecraft:spawn",
+            "minecraft:postprocessed",
+            "minecraft:fullchunk",
+        ];
         if !OK_STATUSES.contains(&status.as_str()) {
             // Chunks that have been fully generated will have a 'full' status.
             // Skip chunks that don't; the way they render is unpredictable.
@@ -85,7 +94,7 @@ impl<'a, P: Palette> TopShadeRenderer<'a, P> {
             let current_block = chunk.block(x, y, z);
 
             if let Some(current_block) = current_block {
-                match current_block.archetype {
+                match current_block.archetype() {
                     BlockArchetype::Airy => {
                         y -= 1;
                     }
@@ -149,7 +158,7 @@ fn water_depth<C: Chunk + ?Sized>(
             None => return depth,
         };
 
-        if block.archetype == BlockArchetype::Watery {
+        if block.archetype() == BlockArchetype::Watery {
             depth += 1;
         } else {
             return depth;

--- a/fastanvil/src/rendered_palette.rs
+++ b/fastanvil/src/rendered_palette.rs
@@ -118,7 +118,7 @@ impl Palette for RenderedPalette {
 
         let col = self
             .blockstates
-            .get(block.encoded_description())
+            .get(&block.encoded_description())
             .or_else(|| self.blockstates.get(block.name()));
 
         match col {


### PR DESCRIPTION
Largely similar to the old block API.

- Allows creating blocks (previously we couldn't, as far as I can tell)
- Revert to using a hashmap for properties (makes the downstream code more straightforward vs having this library create a string and then having the downstream user have to deserialize that string)