### PR TITLE
Fix 'no root compound' error when serializing bool

### DIFF
--- a/fastnbt/src/ser/serializer.rs
+++ b/fastnbt/src/ser/serializer.rs
@@ -367,7 +367,8 @@ impl<'a, W: 'a + Write> serde::ser::Serializer for &'a mut Delayed<'a, W> {
 
     fn serialize_bool(self, v: bool) -> Result<()> {
         self.write_header(Tag::Byte)?;
-        self.ser.serialize_bool(v)
+        self.ser.writer.write_u8(v as u8)?;
+        Ok(())
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {


### PR DESCRIPTION
This was reported in #64 and fixed in 48faa90c966112fe534d6867eb0e0a1e4e086525, but that appears to have been done on another branch which I don't think was merged into master, so the issue appears to persist.