### PR TITLE
feat: btreemap

### DIFF
--- a/fastnbt/Cargo.toml
+++ b/fastnbt/Cargo.toml
@@ -19,6 +19,7 @@ serde_bytes = "0.11.5"
 
 [features]
 arbitrary1 = ["arbitrary"]
+btreemap = []
 
 [dev-dependencies]
 flate2 = "1"

--- a/fastnbt/src/macros.rs
+++ b/fastnbt/src/macros.rs
@@ -268,12 +268,12 @@ macro_rules! nbt_internal {
     };
 
     ({}) => {
-        $crate::Value::Compound(std::collections::HashMap::new())
+        $crate::Value::Compound($crate::value::Map::new())
     };
 
     ({ $($tt:tt)+ }) => {
         $crate::Value::Compound({
-            let mut object = std::collections::HashMap::new();
+            let mut object = $crate::value::Map::new();
             nbt_internal!(@object object () ($($tt)+) ($($tt)+));
             object
         })

--- a/fastnbt/src/value/de.rs
+++ b/fastnbt/src/value/de.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 use serde::{
     de::{
@@ -11,6 +11,8 @@ use serde::{
 use serde_bytes::ByteBuf;
 
 use crate::{error::Error, ByteArray, IntArray, LongArray, Value};
+
+use super::Map;
 
 impl<'de> Deserialize<'de> for Value {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -100,7 +102,7 @@ impl<'de> Deserialize<'de> for Value {
             {
                 match map.next_key_seed(KeyClassifier)? {
                     Some(KeyClass::Compound(first_key)) => {
-                        let mut compound = HashMap::new();
+                        let mut compound = Map::new();
 
                         compound.insert(first_key, map.next_value()?);
                         while let Some((key, value)) = map.next_entry()? {
@@ -252,10 +254,7 @@ where
     }
 }
 
-fn visit_compound<'de, V>(
-    compound: &'de HashMap<String, Value>,
-    visitor: V,
-) -> Result<V::Value, Error>
+fn visit_compound<'de, V>(compound: &'de Map<String, Value>, visitor: V) -> Result<V::Value, Error>
 where
     V: Visitor<'de>,
 {
@@ -735,12 +734,12 @@ impl<'de> SeqAccess<'de> for SeqDeserializer<'de> {
 }
 
 struct MapDeserializer<'de> {
-    iter: <&'de HashMap<String, Value> as IntoIterator>::IntoIter,
+    iter: <&'de Map<String, Value> as IntoIterator>::IntoIter,
     value: Option<&'de Value>,
 }
 
 impl<'de> MapDeserializer<'de> {
-    fn new(map: &'de HashMap<String, Value>) -> Self {
+    fn new(map: &'de Map<String, Value>) -> Self {
         MapDeserializer {
             iter: map.iter(),
             value: None,

--- a/fastnbt/src/value/mod.rs
+++ b/fastnbt/src/value/mod.rs
@@ -2,7 +2,10 @@ mod array_serializer;
 mod de;
 mod ser;
 
-use std::collections::HashMap;
+#[cfg(feature = "btreemap")]
+pub type Map<K, V> = std::collections::BTreeMap<K, V>;
+#[cfg(not(feature = "btreemap"))]
+pub type Map<K, V> = std::collections::HashMap<K, V>;
 
 use serde::{serde_if_integer128, Deserialize, Serialize};
 
@@ -44,7 +47,7 @@ pub enum Value {
     IntArray(IntArray),
     LongArray(LongArray),
     List(Vec<Value>),
-    Compound(HashMap<String, Value>),
+    Compound(Map<String, Value>),
 }
 
 #[cfg(feature = "arbitrary1")]

--- a/fastnbt/src/value/ser.rs
+++ b/fastnbt/src/value/ser.rs
@@ -1,5 +1,4 @@
 use core::result;
-use std::collections::HashMap;
 
 use serde::{ser::Impossible, serde_if_integer128, Serialize};
 
@@ -9,7 +8,7 @@ use crate::{
     LONG_ARRAY_TOKEN,
 };
 
-use super::array_serializer::ArraySerializer;
+use super::{array_serializer::ArraySerializer, Map};
 
 impl Serialize for Value {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
@@ -275,7 +274,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
         Ok(SerializeMap {
-            map: HashMap::new(),
+            map: Map::new(),
             next_key: None,
         })
     }
@@ -293,7 +292,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     ) -> Result<Self::SerializeStructVariant> {
         Ok(SerializeStructVariant {
             name: variant.into(),
-            map: HashMap::new(),
+            map: Map::new(),
         })
     }
 
@@ -327,13 +326,13 @@ pub struct SerializeTupleVariant {
 }
 
 pub struct SerializeMap {
-    map: HashMap<String, Value>,
+    map: Map<String, Value>,
     next_key: Option<String>,
 }
 
 pub struct SerializeStructVariant {
     name: String,
-    map: HashMap<String, Value>,
+    map: Map<String, Value>,
 }
 
 impl serde::ser::SerializeSeq for SerializeVec {
@@ -398,7 +397,7 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     }
 
     fn end(self) -> Result<Value> {
-        let mut object = HashMap::new();
+        let mut object = Map::new();
 
         object.insert(self.name, Value::List(self.vec));
 
@@ -661,7 +660,7 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     }
 
     fn end(self) -> Result<Value> {
-        let mut object = HashMap::new();
+        let mut object = Map::new();
 
         object.insert(self.name, Value::Compound(self.map));
 


### PR DESCRIPTION
This PR introduces a new `btreemap` feature. When this feature is enabled, the `HashMap` in `fastnbt::Value::Compound` will be replaced with a `BTreeMap`. This feature is disabled by default, so it is expected not to conflict with any existing code.

## Motivation

In certain scenarios, I need to ensure that the serialization result of `Value` is consistent. Here is an example:
```rust
#[test]
fn test_fastnbt_works() {
    use fastnbt::{Value, nbt};
    let x = nbt!({
        "string": "Hello World",
        "number": 42,
        "nested": {
            "array": [1, 2, 3, 4, 5],
            "compound": {
                "name": "test",
                "value": 3.14,
                "list": ["a", "b", "c"]
            }
        },
        "boolean": 1_i8,
        "long_array": [1_i64, 2_i64, 3_i64]
    });

    let y = fastnbt::to_bytes(&x).unwrap();
    let z: Value = fastnbt::from_bytes(&y).unwrap();
    let w = fastnbt::to_bytes(&z).unwrap();
    assert_eq!(x, z);
    assert_eq!(y, w);
}
```
In the previous implementation, since `HashMap` does not guarantee iteration order, the serialization result of the same `Value` might be different. That is, in the above test, the assertion `x == z` passes, but the assertion `y == w` fails.

I tried to use a custom `Value` type to solve this problem, but it resulted in an error `Error: Error("invalid nbt: no root compound")` (see #124).

## Todo list

The following tasks may still need to be completed for this PR:
- [ ] Relevant documentation
- [ ] Relevant tests

Although I can complete the above tasks myself, I would still like to get feedback from the project maintainers before proceeding, in order to avoid unnecessary work.