### PR TITLE
Fix serializing empty compound

### DIFF
--- a/fastsnbt/src/ser/mod.rs
+++ b/fastsnbt/src/ser/mod.rs
@@ -415,7 +415,10 @@ impl<'a, W: Write + 'a> SerializeMap for CompoundSerializer<'a, W> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        if self.is_compound {
+        if !self.has_first {
+            // No key-value pair is serialized, write an empty compound
+            self.serializer.writer.write_all(b"{}")?;
+        } else if self.is_compound {
             self.serializer.writer.write_all(b"}")?;
         }
         Ok(())

--- a/fastsnbt/src/tests/ser_tests.rs
+++ b/fastsnbt/src/tests/ser_tests.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::to_string;
 use serde::Serialize;
 use fastnbt::{ByteArray, IntArray, LongArray};
@@ -80,6 +82,13 @@ fn test_struct() {
     let data = SimpleStruct { x: 10, y: "test" };
     let snbt = to_string(&data).unwrap();
     assert_eq!("{\"x\":10b,\"y\":\"test\"}", snbt);
+}
+
+#[test]
+fn test_empty_map() {
+    let data: HashMap<String, String> = HashMap::new();
+    let snbt = to_string(&data).unwrap();
+    assert_eq!("{}", snbt);
 }
 
 #[test]


### PR DESCRIPTION
When serializing empty compound, e.g.
``` rust
fn main() {
    let value: Value = fastsnbt::from_str("{ArmorItems:[{},{},{},{}]}").unwrap();
    let snbt = fastsnbt::to_string(&value).unwrap();
    println!("SNBT: {snbt}");
}
```
I got the incorrect output: `{"ArmorItems":[,,,]}`.

It seems that if there are no fields in a map, `CompoundSerializer` won't create anything. I fixed it by checking `has_first` in `end(self)`.

And I also found that unit struct is banned from serializing, I'm not sure if it's intentional or we can treat it as empty compound? At least in old Minecraft (e.g. 1.21.1, but not 1.21.8), it uses empty compound `{}` in `ArmorItems` to indicate the absence of armor.