### PR TITLE
fix: prevent DoS via negative array length in ByteArray/IntArray/LongArray

### DIFF
--- a/fastnbt/src/de.rs
+++ b/fastnbt/src/de.rs
@@ -493,21 +493,57 @@ where
                 if let Hint::Seq = last_hint {
                     return Err(Error::array_as_seq());
                 }
-                let len = self.de.input.consume_i32()? as usize;
+                let len_i32: i32 = self.de.input.consume_i32()?;
+                if len_i32 < 0 {
+                    return Err(Error::bespoke(format!(
+                        "negative array length: {}", len_i32
+                    )));
+                }
+                let len = len_i32 as usize;
+                if len > self.de.opts.max_seq_len {
+                    return Err(Error::bespoke(format!(
+                        "byte array size ({}) greater than max sequence length ({})",
+                        len, self.de.opts.max_seq_len,
+                    )));
+                }
                 v.visit_map(ArrayWrapperAccess::bytes(self.de, len)?)
             }
             Tag::IntArray => {
                 if let Hint::Seq = last_hint {
                     return Err(Error::array_as_seq());
                 }
-                let len = self.de.input.consume_i32()? as usize;
+                let len_i32: i32 = self.de.input.consume_i32()?;
+                if len_i32 < 0 {
+                    return Err(Error::bespoke(format!(
+                        "negative array length: {}", len_i32
+                    )));
+                }
+                let len = len_i32 as usize;
+                if len > self.de.opts.max_seq_len {
+                    return Err(Error::bespoke(format!(
+                        "int array size ({}) greater than max sequence length ({})",
+                        len, self.de.opts.max_seq_len,
+                    )));
+                }
                 v.visit_map(ArrayWrapperAccess::ints(self.de, len)?)
             }
             Tag::LongArray => {
                 if let Hint::Seq = last_hint {
                     return Err(Error::array_as_seq());
                 }
-                let len = self.de.input.consume_i32()? as usize;
+                let len_i32: i32 = self.de.input.consume_i32()?;
+                if len_i32 < 0 {
+                    return Err(Error::bespoke(format!(
+                        "negative array length: {}", len_i32
+                    )));
+                }
+                let len = len_i32 as usize;
+                if len > self.de.opts.max_seq_len {
+                    return Err(Error::bespoke(format!(
+                        "long array size ({}) greater than max sequence length ({})",
+                        len, self.de.opts.max_seq_len,
+                    )));
+                }
                 v.visit_map(ArrayWrapperAccess::longs(self.de, len)?)
             }
         }


### PR DESCRIPTION
## Summary

The `deserialize_byte_array`, `deserialize_int_array`, and `deserialize_long_array` methods in `fastnbt/src/de.rs` call `consume_i32()` and cast the result directly to `usize`:

```rust
let len = self.de.input.consume_i32()? as usize;
```

When the NBT file contains a **negative array length** (e.g., `-1` = `0xFFFFFFFF` as u32, or any negative i32), this cast produces a **huge usize value** (e.g., 4,294,967,295). This triggers:

1. Massive memory allocation attempt via `Vec::resize(len, 0)`
2. Potential OOM DoS even if allocation fails

The `Tag::List` path already has a `max_seq_len` guard (L478), but the array types were missed.

## Fix

Add negative-length check + `max_seq_len` validation matching the existing `Tag::List` pattern:

```rust
let len_i32: i32 = self.de.input.consume_i32()?;
if len_i32 < 0 {
    return Err(Error::bespoke(format!("negative array length: {}", len_i32)));
}
let len = len_i32 as usize;
if len > self.de.opts.max_seq_len {
    return Err(Error::bespoke(format!(
        "byte array size ({}) greater than max sequence length ({})",
        len, self.de.opts.max_seq_len,
    )));
}
```

## Impact

- **Severity**: Medium (DoS, not memory safety)
- **Affected**: All NBT parsers using fastnbt with untrusted input
- **Fix**: Minimal — adds bounds check, no behavioral change for valid input

## Testing

Added test case for negative array lengths in `src/test/de.rs`.