### PR TITLE
Support of Options in fastsnbt

### DIFF
--- a/fastsnbt/src/de.rs
+++ b/fastsnbt/src/de.rs
@@ -134,9 +134,17 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
         Ok(value)
     }
 
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Presence is not encoded in SNBT, if deserialize_option is called, "Some" can be assumed
+        visitor.visit_some(self)
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq
+        bytes byte_buf unit unit_struct newtype_struct seq
         tuple tuple_struct map struct identifier
     }
 

--- a/fastsnbt/src/ser/compound_value_serializer.rs
+++ b/fastsnbt/src/ser/compound_value_serializer.rs
@@ -1,0 +1,140 @@
+use std::io::Write;
+use serde::ser::Impossible;
+use serde::Serialize;
+use crate::error::Error;
+use super::{ArraySerializer, CompoundSerializer};
+
+/// Serializer for compound values. This forwards everything except serialize_none to Serializer
+/// The purpose is to be able to drop a field from the compound entirely if its None
+pub(crate) struct CompoundValueSerializer<'a,'b: 'a, W> {
+    pub(crate) ser: &'a mut CompoundSerializer<'b, W>,
+    pub(crate) name: &'a[u8],
+    pub(crate) is_first: bool
+}
+
+impl<'a,'b, W: Write> CompoundValueSerializer<'a,'b, W> {
+    fn write_name(&mut self) -> Result<(), Error> {
+        self.ser.serializer.writer.write_all(self.name)?;
+        self.ser.serializer.writer.write_all(b":")?;
+        Ok(())
+    }
+}
+
+macro_rules! forward_serialisation {
+    ($name:ident, $t:ty) => {
+        fn $name(mut self, v: $t) -> Result<Self::Ok, Self::Error> {
+            self.write_name()?;
+            self.ser.serializer.$name(v)
+        }
+    };
+}
+
+impl<'a,'b, W: Write> serde::Serializer for CompoundValueSerializer<'a,'b, W> {
+    type Ok = ();
+    type Error = Error;
+    type SerializeSeq = ArraySerializer<'a, W>;
+    type SerializeTuple = ArraySerializer<'a, W>;
+    type SerializeTupleStruct = ArraySerializer<'a, W>;
+    type SerializeTupleVariant = ArraySerializer<'a, W>;
+    type SerializeMap = CompoundSerializer<'a, W>;
+    type SerializeStruct = CompoundSerializer<'a, W>;
+    type SerializeStructVariant = Impossible<(), Error>;
+
+
+    forward_serialisation!(serialize_bool, bool);
+    forward_serialisation!(serialize_i8, i8);
+    forward_serialisation!(serialize_i16, i16);
+    forward_serialisation!(serialize_i32, i32);
+    forward_serialisation!(serialize_i64, i64);
+    forward_serialisation!(serialize_u8, u8);
+    forward_serialisation!(serialize_u16, u16);
+    forward_serialisation!(serialize_u32, u32);
+    forward_serialisation!(serialize_u64, u64);
+    forward_serialisation!(serialize_f32, f32);
+    forward_serialisation!(serialize_f64, f64);
+    forward_serialisation!(serialize_char, char);
+    forward_serialisation!(serialize_str, &str);
+    forward_serialisation!(serialize_bytes, &[u8]);
+
+    /// Don't write the name and colon, if necessary reset has_first so no wrong comma is written
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        if self.is_first {
+            self.ser.has_first = false;
+        }
+        Ok(())
+    }
+
+    fn serialize_some<T>(mut self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize
+    {
+        self.write_name()?;
+        self.ser.serializer.serialize_some(value)
+    }
+
+    fn serialize_unit(mut self) -> Result<Self::Ok, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_unit()
+    }
+
+    fn serialize_unit_struct(mut self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_unit_struct(name)
+    }
+
+    fn serialize_unit_variant(mut self, name: &'static str, variant_index: u32, variant: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_unit_variant(name, variant_index, variant)
+    }
+
+    fn serialize_newtype_struct<T>(mut self, name: &'static str, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize
+    {
+        self.write_name()?;
+        self.ser.serializer.serialize_newtype_struct(name, value)
+    }
+
+    fn serialize_newtype_variant<T>(mut self, name: &'static str, variant_index: u32, variant: &'static str, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize
+    {
+        self.write_name()?;
+        self.ser.serializer.serialize_newtype_variant(name, variant_index, variant, value)
+    }
+
+    fn serialize_seq(mut self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_seq(len)
+    }
+
+    fn serialize_tuple(mut self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_tuple(len)
+    }
+
+    fn serialize_tuple_struct(mut self, name: &'static str, len: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_tuple_struct(name, len)
+    }
+
+    fn serialize_tuple_variant(mut self, name: &'static str, variant_index: u32, variant: &'static str, len: usize) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_tuple_variant(name, variant_index, variant, len)
+    }
+
+    fn serialize_map(mut self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_map(len)
+    }
+
+    fn serialize_struct(mut self, name: &'static str, len: usize) -> Result<Self::SerializeStruct, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_struct(name, len)
+    }
+
+    fn serialize_struct_variant(mut self, name: &'static str, variant_index: u32, variant: &'static str, len: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.write_name()?;
+        self.ser.serializer.serialize_struct_variant(name, variant_index, variant, len)
+    }
+}

--- a/fastsnbt/src/ser/mod.rs
+++ b/fastsnbt/src/ser/mod.rs
@@ -22,6 +22,7 @@ use self::name_serializer::NameSerializer;
 
 mod name_serializer;
 mod array_serializer;
+mod compound_value_serializer;
 
 pub(crate) fn write_escaped_str<W: Write>(mut writer: W, v: &str) -> Result<(), Error> {
     writer.write_all(b"\"")?;
@@ -380,6 +381,8 @@ impl<'a, W: Write + 'a> SerializeMap for CompoundSerializer<'a, W> {
             Error::bespoke("serialize_value called before serialize_key".to_string())
         })?;
 
+        let is_first = !self.has_first;
+
         if !self.has_first {
             self.has_first = true;
         } else {
@@ -407,19 +410,23 @@ impl<'a, W: Write + 'a> SerializeMap for CompoundSerializer<'a, W> {
                     self.is_compound = true;
                     self.serializer.writer.write_all(b"{")?;
                 }
-                self.serializer.writer.write_all(&name)?;
-                self.serializer.writer.write_all(b":")?;
-                value.serialize(&mut *self.serializer)
+                let ser = compound_value_serializer::CompoundValueSerializer{
+                    ser: self,
+                    name: &name,
+                    is_first
+                };
+
+                value.serialize(ser)
             }
         }
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        if !self.has_first {
+        if self.is_compound {
+            self.serializer.writer.write_all(b"}")?;
+        } else if !self.has_first {
             // No key-value pair is serialized, write an empty compound
             self.serializer.writer.write_all(b"{}")?;
-        } else if self.is_compound {
-            self.serializer.writer.write_all(b"}")?;
         }
         Ok(())
     }

--- a/fastsnbt/src/tests/de_tests.rs
+++ b/fastsnbt/src/tests/de_tests.rs
@@ -106,3 +106,17 @@ fn test_unit() {
     assert!(from_str::<UnitStruct>("{}").is_err());
     assert!(from_str::<UnitField>("{_unit: {}}").is_err());
 }
+
+#[test]
+fn test_option() {
+    #[derive(Deserialize)]
+    struct StructWithOption {
+        name: Option<String>
+    }
+
+    let some: StructWithOption = from_str(r#"{name:"Bob"}"#).unwrap();
+    assert_eq!(some.name.unwrap(), "Bob");
+
+    let none: StructWithOption = from_str("{}").unwrap();
+    assert!(none.name.is_none());
+}

--- a/fastsnbt/src/tests/ser_tests.rs
+++ b/fastsnbt/src/tests/ser_tests.rs
@@ -154,3 +154,22 @@ fn test_unit() {
     assert!(to_string(&UnitStruct).is_err());
     assert!(to_string(&UnitField { unit: () }).is_err());
 }
+
+
+#[test]
+fn test_option() {
+    #[derive(Serialize)]
+    struct StructWithOption {
+        name: Option<String>
+    }
+
+    let some = StructWithOption {
+        name: Some("Bob".to_owned())
+    };
+    assert_eq!(to_string(&some).unwrap(), r#"{"name":"Bob"}"#);
+
+    let none = StructWithOption {
+        name: None
+    };
+    assert_eq!(to_string(&none).unwrap(), "{}");
+}


### PR DESCRIPTION
Optional values are all over the place in Minecrafts SNBT values (e.g. a TextComponent)
Therefore support for rusts Option<> is really useful.
My approach for serialization is to add a extra serializer for compund values. With that you can delay writing the name of a field until you know it is present.